### PR TITLE
refactor: Bookmark 엔티티 캡슐화 — @Setter 제거 및 도메인 메서드 도입

### DIFF
--- a/src/main/java/com/example/calenduck/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/example/calenduck/domain/bookmark/entity/Bookmark.java
@@ -1,11 +1,10 @@
 package com.example.calenduck.domain.bookmark.entity;
 
-import com.example.calenduck.domain.bookmark.dto.request.EditBookmarkRequestDto;
 import com.example.calenduck.domain.user.entity.User;
 import com.example.calenduck.global.entity.BaseTimeEntity;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.Index;
 
 import javax.persistence.*;
@@ -13,10 +12,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Setter
-@NoArgsConstructor
-//@Where(clause = "deleted_at IS NULL")
-//@SQLDelete(sql = "UPDATE bookmark SET deleted_at = CONVERT_TZ(now(), 'UTC', 'Asia/Seoul') WHERE id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Bookmark extends BaseTimeEntity {
 
     @Id
@@ -48,8 +44,20 @@ public class Bookmark extends BaseTimeEntity {
         this.reservationDate = reservationDate;
     }
 
-    public void updateBookmark(EditBookmarkRequestDto editBookmarkRequestDto) {
-        this.content = editBookmarkRequestDto.getContent();
-        this.alarm = editBookmarkRequestDto.getAlarm();
+    public void updateContent(String content, String alarm) {
+        this.content = content;
+        this.alarm = alarm;
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public void restore() {
+        this.deletedAt = null;
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 }

--- a/src/main/java/com/example/calenduck/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/example/calenduck/domain/bookmark/service/BookmarkService.java
@@ -37,7 +37,7 @@ public class BookmarkService implements BookmarkBehavior{
     private final NameWithMt20idRepository nameWithMt20idRepository;
     private final HttpRequest httpRequest;
     private final DataConversion dataConversion;
-    private final EditBookmarkMapper editBookmarkMapper;
+
 
     // 북마크 성공/취소
     @Override
@@ -60,10 +60,10 @@ public class BookmarkService implements BookmarkBehavior{
 
         Bookmark bookmark = bookmarkRepository.findByUserAndMt20idAndReservationDate(user, mt20id, reservationDate);
         if (bookmark != null) {
-            if (bookmark.getDeletedAt() == null) {
-                bookmark.setDeletedAt(LocalDateTime.now());
+            if (!bookmark.isDeleted()) {
+                bookmark.softDelete();
             } else {
-                bookmark.setDeletedAt(null);
+                bookmark.restore();
             }
         } else {
             bookmark = new Bookmark(mt20id, user, reservationDate);
@@ -71,9 +71,8 @@ public class BookmarkService implements BookmarkBehavior{
 
         bookmarkRepository.saveAndFlush(bookmark);
 
-        if (bookmark.getDeletedAt() != null) {
-            LocalDateTime deletedAt = bookmark.getDeletedAt();
-            return new BookmarkResponseDto("찜목록 취소", deletedAt);
+        if (bookmark.isDeleted()) {
+            return new BookmarkResponseDto("찜목록 취소", bookmark.getDeletedAt());
         } else {
             LocalDateTime createdAt = bookmark.getCreatedAt();
             return new BookmarkResponseDto("찜목록 성공", createdAt, reservationDate);
@@ -186,23 +185,18 @@ public class BookmarkService implements BookmarkBehavior{
             resultBuilder.append(formattedDate);
         }
 
-        String result = resultBuilder.toString();
-        log.info("Result: " + result);
-        editBookmarkRequestDto.setAlarm(result);
-        log.info("editBookmarkRequestDto.setAlarm(result) == " + editBookmarkRequestDto.getAlarm());
+        String alarmDates = resultBuilder.toString();
 
         Bookmark bookmark = findByUserAndMt20idAndReservationDate(user, mt20id, reservationDate);
         if(bookmark == null) {
             throw new GlobalException(GlobalErrorCode.BOOKMARK_NOT_FOUND);
         }
-        if(bookmark.getMt20id().equals(mt20id) && bookmark.getReservationDate().equals(reservationDate) && bookmark.getDeletedAt() != null) {
+        if(bookmark.getMt20id().equals(mt20id) && bookmark.getReservationDate().equals(reservationDate) && bookmark.isDeleted()) {
             throw new GlobalException(GlobalErrorCode.BOOKMARK_NOT_FOUND);
         }
 
         if (reservationDate.equals(bookmark.getReservationDate())) {
-            log.info("bookmark.getReservationDate() = " + bookmark.getReservationDate());
-            log.info("if 들어옴----");
-            editBookmarkMapper.updateBookmarkFromDto(editBookmarkRequestDto, bookmark);
+            bookmark.updateContent(editBookmarkRequestDto.getContent(), alarmDates);
             bookmarkRepository.save(bookmark);
         } else {
             throw new GlobalException(GlobalErrorCode.NOT_VALID_DATE);

--- a/src/test/java/com/example/calenduck/domain/bookmark/entity/BookmarkTest.java
+++ b/src/test/java/com/example/calenduck/domain/bookmark/entity/BookmarkTest.java
@@ -1,6 +1,5 @@
 package com.example.calenduck.domain.bookmark.entity;
 
-import com.example.calenduck.domain.bookmark.dto.request.EditBookmarkRequestDto;
 import com.example.calenduck.domain.user.dto.request.KakaoUserInfoDto;
 import com.example.calenduck.domain.user.entity.User;
 import com.example.calenduck.domain.user.entity.UserRoleEnum;
@@ -34,17 +33,14 @@ class BookmarkTest {
     }
 
     @Test
-    @DisplayName("updateBookmark 호출 시 content와 alarm이 업데이트된다")
-    void updateBookmark_withDto_updatesContentAndAlarm() {
+    @DisplayName("updateContent 호출 시 content와 alarm이 업데이트된다")
+    void updateContent_withParams_updatesFields() {
         // Given
         User user = createTestUser();
         Bookmark bookmark = new Bookmark("PF12345", user, "20240101");
-        EditBookmarkRequestDto dto = new EditBookmarkRequestDto();
-        dto.setContent("테스트 메모");
-        dto.setAlarm("1일전");
 
         // When
-        bookmark.updateBookmark(dto);
+        bookmark.updateContent("테스트 메모", "1일전");
 
         // Then
         assertThat(bookmark.getContent()).isEqualTo("테스트 메모");
@@ -52,14 +48,45 @@ class BookmarkTest {
     }
 
     @Test
-    @DisplayName("Bookmark는 deletedAt 필드를 가진다")
-    void bookmark_hasDeletedAtField() {
+    @DisplayName("softDelete 호출 시 deletedAt이 설정된다")
+    void softDelete_setsDeletedAt() {
+        // Given
+        User user = createTestUser();
+        Bookmark bookmark = new Bookmark("PF12345", user, "20240101");
+
+        // When
+        bookmark.softDelete();
+
+        // Then
+        assertThat(bookmark.getDeletedAt()).isNotNull();
+        assertThat(bookmark.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("restore 호출 시 deletedAt이 null로 초기화된다")
+    void restore_clearsDeletedAt() {
+        // Given
+        User user = createTestUser();
+        Bookmark bookmark = new Bookmark("PF12345", user, "20240101");
+        bookmark.softDelete();
+
+        // When
+        bookmark.restore();
+
+        // Then
+        assertThat(bookmark.getDeletedAt()).isNull();
+        assertThat(bookmark.isDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("삭제되지 않은 Bookmark의 isDeleted는 false다")
+    void isDeleted_whenNotDeleted_returnsFalse() {
         // Given
         User user = createTestUser();
         Bookmark bookmark = new Bookmark("PF12345", user, "20240101");
 
         // When & Then
-        assertThat(bookmark.getDeletedAt()).isNull();
+        assertThat(bookmark.isDeleted()).isFalse();
     }
 
     @Test
@@ -72,21 +99,5 @@ class BookmarkTest {
         // When & Then — JPA 컨텍스트 없이는 null이지만, 필드 존재를 확인
         assertThat(bookmark.getCreatedAt()).isNull();
         assertThat(bookmark.getModifiedAt()).isNull();
-    }
-
-    @Test
-    @DisplayName("기본 생성자로 생성한 Bookmark의 모든 필드는 null이다")
-    void create_withNoArgs_allFieldsNull() {
-        // When
-        Bookmark bookmark = new Bookmark();
-
-        // Then
-        assertThat(bookmark.getId()).isNull();
-        assertThat(bookmark.getMt20id()).isNull();
-        assertThat(bookmark.getContent()).isNull();
-        assertThat(bookmark.getAlarm()).isNull();
-        assertThat(bookmark.getUser()).isNull();
-        assertThat(bookmark.getReservationDate()).isNull();
-        assertThat(bookmark.getDeletedAt()).isNull();
     }
 }


### PR DESCRIPTION
  문제:
  - @Setter로 모든 필드가 외부에서 변경 가능하여 엔티티 무결성 보장 불가
  - Entity가 DTO를 직접 import하는 계층 역전
  - setDeletedAt(now()/null) 직접 호출로 소프트 삭제 의도가 불명확

  해결:
  - @Setter 제거, softDelete()/restore()/isDeleted()/updateContent() 도메인 메서드 도입
  - Entity의 DTO 의존 제거, MapStruct EditBookmarkMapper 제거
  - @NoArgsConstructor(access = PROTECTED)로 JPA 외 기본 생성자 사용 차단
  - Bookmark 도메인 메서드 테스트 작성