### PR TITLE
refactor: 컨벤션 통일 및 미사용 의존성 정리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,19 +22,13 @@ dependencies {
 	implementation 'org.hibernate:hibernate-core'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
 	compileOnly 'org.projectlombok:lombok'
 //	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'mysql:mysql-connector-java:8.0.29'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
-
-	// 소셜로그인
-	compileOnly('org.springframework.boot:spring-boot-starter-oauth2-client')
-	implementation 'org.springframework.boot:spring-boot-starter'
 
 	// jwt
 	compileOnly 'io.jsonwebtoken:jjwt-api:0.11.2'
@@ -52,8 +46,6 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.6'
-	implementation 'io.springfox:springfox-swagger2:2.9.2'
-	implementation 'io.springfox:springfox-swagger-ui:2.9.2'
 
 	// jsoup
 	implementation 'org.jsoup:jsoup:1.14.3'
@@ -63,24 +55,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'io.lettuce:lettuce-core:6.1.5.RELEASE'
 
-	// dto검사 Mapper용
-	implementation 'org.mapstruct:mapstruct:1.5.3.Final'
-	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
-
-	// prometheus
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'io.micrometer:micrometer-registry-prometheus'
-
 	// flyway
 	implementation'org.flywaydb:flyway-core:6.4.2'
 
 	// dotenv (.env 파일에서 환경변수 로드)
 	implementation 'me.paulschwarz:spring-dotenv:2.5.4'
-
-	// dotenv (.env 파일에서 환경변수 로드)
-	implementation 'me.paulschwarz:spring-dotenv:2.5.4'
-
-
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/calenduck/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/example/calenduck/domain/bookmark/entity/Bookmark.java
@@ -5,14 +5,13 @@ import com.example.calenduck.global.entity.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Index;
-
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = @Index(name = "idx_mt20id", columnList = "mt20id"))
 public class Bookmark extends BaseTimeEntity {
 
     @Id
@@ -20,7 +19,6 @@ public class Bookmark extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false)
-    @Index(name = "idx_mt20id")
     private String mt20id;
 
     @Column

--- a/src/main/java/com/example/calenduck/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/example/calenduck/domain/bookmark/service/BookmarkService.java
@@ -16,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.LocalDate;

--- a/src/main/java/com/example/calenduck/domain/detailInfo/entity/DetailInfo.java
+++ b/src/main/java/com/example/calenduck/domain/detailInfo/entity/DetailInfo.java
@@ -1,7 +1,6 @@
 package com.example.calenduck.domain.detailInfo.entity;
 
 import lombok.Getter;
-import org.hibernate.annotations.Index;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -12,7 +11,6 @@ import javax.persistence.Id;
 public class DetailInfo {
 
     @Id
-    @Index(name = "idx_mt20id")
     private String mt20id;
 
     @Column

--- a/src/main/java/com/example/calenduck/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/com/example/calenduck/domain/performance/controller/PerformanceController.java
@@ -42,14 +42,14 @@ public class PerformanceController {
 
     @Operation(summary = "장르별 인기도 - 지역별", description = "장르별 인기도 - 지역별")
     @GetMapping("/popularity/genres/region")
-    public ResponseEntity<?> PopularityByGenreWithRegion() {
-        return ResponseMessage.SuccessResponse("장르별 인기도 - 지역별", performanceAnalyticsBehavior.PopularityByGenreWithRegion());
+    public ResponseEntity<?> popularityByGenreWithRegion() {
+        return ResponseMessage.SuccessResponse("장르별 인기도 - 지역별", performanceAnalyticsBehavior.popularityByGenreWithRegion());
     }
 
 //    @Operation(summary = "장르별 인기도 - 랭킹점수 가산", description = "장르별 인기도 - 랭킹점수 가산")
 //    @GetMapping("/popularity/genre/rank")
-//    public ResponseEntity<?> PopularityByRegion() {
-//        return ResponseMessage.SuccessResponse("장르별 인기도 - 랭킹점수 가산", performanceService.PopularityByRegion());
+//    public ResponseEntity<?> popularityByRegion() {
+//        return ResponseMessage.SuccessResponse("장르별 인기도 - 랭킹점수 가산", performanceService.popularityByRegion());
 //    }
 
     @Operation(summary = "Top 10", description = "Top 10")
@@ -60,8 +60,8 @@ public class PerformanceController {
 
     @Operation(summary = "지역별 인기 공연", description = "지역별 인기 공연")
     @GetMapping("/popularity/region")
-    public ResponseEntity<?> PopularityByRegion() {
-        return ResponseMessage.SuccessResponse("지역별 인기 공연", performanceAnalyticsBehavior.PopularityByRegion());
+    public ResponseEntity<?> popularityByRegion() {
+        return ResponseMessage.SuccessResponse("지역별 인기 공연", performanceAnalyticsBehavior.popularityByRegion());
     }
 
 }

--- a/src/main/java/com/example/calenduck/domain/performance/http/BatchManager.java
+++ b/src/main/java/com/example/calenduck/domain/performance/http/BatchManager.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Component;
 
-import javax.transaction.Transactional;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -26,7 +25,6 @@ public class BatchManager {
     private final DataConversion dataConversion;
     private final NameWithMt20idRepository nameWithMt20idRepository;
 
-    @Transactional
     public List<Elements> getElements() throws InterruptedException, ExecutionException {
         try{
             List<String> duplicateMt20ids = nameWithMt20idRepository.findAllMt20idsOrdered();

--- a/src/main/java/com/example/calenduck/domain/performance/http/HttpRequest.java
+++ b/src/main/java/com/example/calenduck/domain/performance/http/HttpRequest.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import javax.transaction.Transactional;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -24,7 +23,6 @@ public class HttpRequest {
     @Value("${request.last-url}")
     private String lastUrl;
 
-    @Transactional
     public String requestExtraction(String mt20id) throws IOException {
         URL url = new URL(firstUrl + mt20id + lastUrl);
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();

--- a/src/main/java/com/example/calenduck/domain/performance/repository/NameWithMt20idRepository.java
+++ b/src/main/java/com/example/calenduck/domain/performance/repository/NameWithMt20idRepository.java
@@ -4,12 +4,10 @@ import com.example.calenduck.domain.performance.entity.NameWithMt20id;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import javax.transaction.Transactional;
 import java.util.List;
 
 public interface NameWithMt20idRepository extends JpaRepository<NameWithMt20id, String> {
 
-    @Transactional
     @Query("SELECT n.mt20id FROM NameWithMt20id n ORDER BY n.mt20id ASC")
     List<String> findAllMt20idsOrdered();
     boolean existsByMt20id(String mt20id);

--- a/src/main/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsBehavior.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsBehavior.java
@@ -3,7 +3,7 @@ package com.example.calenduck.domain.performance.service;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public interface PerformanceAnalyticsBehavior {
-    JsonNode PopularityByGenreWithRegion(); // 지역별 장르 인기도
+    JsonNode popularityByGenreWithRegion(); // 지역별 장르 인기도
     JsonNode topTen(); // 인기 공연 탑텐
-    JsonNode PopularityByRegion(); // 지역별 인기 공연
+    JsonNode popularityByRegion(); // 지역별 인기 공연
 }

--- a/src/main/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsService.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsService.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -33,8 +32,7 @@ public class PerformanceAnalyticsService implements PerformanceAnalyticsBehavior
 
     // 인기도 - 지역별 장르
     @Override
-    @Transactional
-    public JsonNode PopularityByGenreWithRegion() {
+    public JsonNode popularityByGenreWithRegion() {
         String url = serverUrl + "/api/queries/3/results.json?api_key=" + genreRegionApiKey;
         JsonNode rowsNode = null;
 
@@ -83,7 +81,6 @@ public class PerformanceAnalyticsService implements PerformanceAnalyticsBehavior
 
     // 탑텐
     @Override
-    @Transactional
     public JsonNode topTen() {
         String url = serverUrl + "/api/queries/5/results.json?api_key=" + topTenApiKey;
         JsonNode rowsNode = null;
@@ -126,8 +123,7 @@ public class PerformanceAnalyticsService implements PerformanceAnalyticsBehavior
 
     // 지역별 인기 공연
     @Override
-    @Transactional
-    public JsonNode PopularityByRegion() {
+    public JsonNode popularityByRegion() {
         String url = serverUrl + "/api/queries/1/results.json?api_key=" + regionApiKey;
         JsonNode rowsNode = null;
 

--- a/src/main/java/com/example/calenduck/domain/performance/service/PerformanceSearchService.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/PerformanceSearchService.java
@@ -6,7 +6,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -22,13 +21,11 @@ public class PerformanceSearchService implements PerformanceSearchBehavior {
     //    Pub/Sub 메시징 시스템을 사용하여 메시지 발행 및 구독.
 
     @Override
-    @Transactional
     public void updatePopularSearchWord(String searchTerm) {
         redisTemplate.opsForZSet().incrementScore("rank", searchTerm, 1);
     }
 
     @Override
-    @Transactional
     public List<SearchRankResponseDto> searchRankList() {
         String key = "rank";
         // ZSetOperations 객체 생성

--- a/src/main/java/com/example/calenduck/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/PerformanceService.java
@@ -8,7 +8,7 @@ import org.jsoup.select.Elements;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;


### PR DESCRIPTION
  문제:
  - 7개 파일에서spring  표준  Transactional 사용하지 않음
  - HttpRequest, BatchManager, PerformanceSearchService 등, @Transactional 적용
  - 메서드명 PopularityByGenreWithRegion, PopularityByRegion이 camelCase 위반
  - 미사용 의존성 발견
  - deprecated org.hibernate.annotations.Index 사용
  - 중복 의존 선언

  해결:
  - javax.transaction → org.springframework.transaction 교체 (3개 파일)
  - 불필요한 @Transactional 제거 (4개 파일: HttpRequest, BatchManager, NameWithMt20idRepository, PerformanceSearchService)
  - 메서드명 camelCase 통일 (인터페이스 + 구현체 + Controller)
  - 미사용 의존성 7개 + 중복 선언 제거
  - @Index를 JPA 표준 @Table(indexes) 방식으로 교체, PK에 불필요한 @Index 제거