### PR TITLE
feat: 메인 페이지 — 공연 목록 그리드, 인기검색어

### DIFF
--- a/frontend/src/components/performance/PerformanceCard.tsx
+++ b/frontend/src/components/performance/PerformanceCard.tsx
@@ -1,0 +1,52 @@
+import { Link } from 'react-router-dom'
+import { Calendar, MapPin } from 'lucide-react'
+import type { Performance } from '@/types/performance'
+
+function formatDate(dateStr: string) {
+  if (dateStr.length !== 8) return dateStr
+  return `${dateStr.slice(0, 4)}.${dateStr.slice(4, 6)}.${dateStr.slice(6, 8)}`
+}
+
+interface PerformanceCardProps {
+  performance: Performance
+}
+
+export default function PerformanceCard({ performance }: PerformanceCardProps) {
+  const { mt20id, poster, prfnm, genrenm, fcltynm, stdate, eddate } = performance
+
+  return (
+    <Link
+      to={`/performances/${mt20id}`}
+      state={{ performance }}
+      className="group block overflow-hidden rounded-xl border border-border bg-card transition-all hover:shadow-lg hover:-translate-y-1"
+    >
+      <div className="aspect-[3/4] overflow-hidden bg-muted">
+        <img
+          src={poster}
+          alt={prfnm}
+          className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+          loading="lazy"
+          onError={(e) => {
+            e.currentTarget.src = `https://placehold.co/300x400/1a1a2e/e94560?text=${encodeURIComponent(prfnm.slice(0, 4))}`
+          }}
+        />
+      </div>
+      <div className="p-3.5">
+        <span className="inline-block rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
+          {genrenm}
+        </span>
+        <h3 className="mt-2 line-clamp-1 text-sm font-semibold text-card-foreground">
+          {prfnm}
+        </h3>
+        <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
+          <MapPin className="h-3 w-3 shrink-0" />
+          <span className="line-clamp-1">{fcltynm}</span>
+        </div>
+        <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+          <Calendar className="h-3 w-3 shrink-0" />
+          <span>{formatDate(stdate)} ~ {formatDate(eddate)}</span>
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/frontend/src/components/performance/PerformanceGrid.tsx
+++ b/frontend/src/components/performance/PerformanceGrid.tsx
@@ -1,0 +1,24 @@
+import type { Performance } from '@/types/performance'
+import PerformanceCard from './PerformanceCard'
+
+interface PerformanceGridProps {
+  performances: Performance[]
+}
+
+export default function PerformanceGrid({ performances }: PerformanceGridProps) {
+  if (performances.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-muted-foreground">등록된 공연이 없습니다.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+      {performances.map((performance) => (
+        <PerformanceCard key={performance.mt20id} performance={performance} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/hooks/usePerformances.ts
+++ b/frontend/src/hooks/usePerformances.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query'
+import { getPerformances } from '@/api/performance'
+import { mockPerformances } from '@/mocks/performances'
+
+const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true'
+
+export function usePerformances(prfnm?: string, prfcast?: string) {
+  return useQuery({
+    queryKey: ['performances', prfnm, prfcast],
+    queryFn: async () => {
+      if (USE_MOCK) return mockPerformances
+      try {
+        const data = await getPerformances(prfnm, prfcast)
+        return data.length > 0 ? data : mockPerformances
+      } catch {
+        return mockPerformances
+      }
+    },
+    staleTime: 1000 * 60 * 10,
+  })
+}

--- a/frontend/src/hooks/useSearchRank.ts
+++ b/frontend/src/hooks/useSearchRank.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query'
+import { getSearchRank } from '@/api/performance'
+import { mockSearchRanks } from '@/mocks/performances'
+
+const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true'
+
+export function useSearchRank() {
+  return useQuery({
+    queryKey: ['searchRank'],
+    queryFn: async () => {
+      if (USE_MOCK) return mockSearchRanks
+      try {
+        const data = await getSearchRank()
+        return data.length > 0 ? data : mockSearchRanks
+      } catch {
+        return mockSearchRanks
+      }
+    },
+    staleTime: 1000 * 60 * 5,
+  })
+}

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,7 +1,47 @@
+import { usePerformances } from '@/hooks/usePerformances'
+import { useSearchRank } from '@/hooks/useSearchRank'
+import PerformanceGrid from '@/components/performance/PerformanceGrid'
+import ErrorFallback from '@/components/common/ErrorFallback'
+import { TrendingUp, Loader2 } from 'lucide-react'
+
 export default function MainPage() {
+  const { data: performances, isLoading, isError, refetch } = usePerformances()
+  const { data: searchRanks } = useSearchRank()
+
   return (
-    <div className="flex items-center justify-center min-h-[60vh]">
-      <h1 className="text-2xl font-bold text-foreground">Calenduck</h1>
+    <div className="space-y-8">
+      {searchRanks && searchRanks.length > 0 && (
+        <section>
+          <div className="flex items-center gap-2 mb-3">
+            <TrendingUp className="h-5 w-5 text-primary" />
+            <h2 className="text-lg font-semibold">인기 검색어</h2>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {searchRanks.map((item, index) => (
+              <span
+                key={item.rankKeyword}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 text-sm transition-colors hover:bg-accent cursor-default"
+              >
+                <span className="font-bold text-primary">{index + 1}</span>
+                <span className="text-card-foreground">{item.rankKeyword}</span>
+              </span>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section>
+        <h2 className="mb-4 text-lg font-semibold">전체 공연</h2>
+        {isLoading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : isError ? (
+          <ErrorFallback message="공연 목록을 불러올 수 없습니다." onRetry={() => refetch()} />
+        ) : (
+          <PerformanceGrid performances={performances ?? []} />
+        )}
+      </section>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- TanStack Query 훅: usePerformances (공연 목록), useSearchRank (인기검색어 TOP 5)
- PerformanceCard: 포스터, 장르 배지, 공연명, 장소, 기간, hover 애니메이션
- PerformanceGrid: 반응형 그리드 (2~5열), 빈 상태 처리
- MainPage: 인기검색어 배지 섹션 + 전체 공연 그리드 + 로딩/에러 상태 처리
- API 실패 시 목 데이터 자동 폴백