### PR TITLE
feat: 카카오 OAuth 콜백 페이지

### DIFF
--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -1,7 +1,41 @@
+import { useEffect, useRef } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+import { kakaoLogin } from '@/api/user'
+import { Loader2 } from 'lucide-react'
+
 export default function OAuthCallbackPage() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const { login } = useAuth()
+  const processed = useRef(false)
+
+  useEffect(() => {
+    if (processed.current) return
+    processed.current = true
+
+    const code = searchParams.get('code')
+    if (!code) {
+      navigate('/', { replace: true })
+      return
+    }
+
+    kakaoLogin(code)
+      .then((token) => {
+        if (token) {
+          login(token)
+        }
+        navigate('/', { replace: true })
+      })
+      .catch(() => {
+        navigate('/', { replace: true })
+      })
+  }, [searchParams, navigate, login])
+
   return (
-    <div className="flex items-center justify-center min-h-[60vh]">
-      <p className="text-muted-foreground">로그인 처리 중...</p>
+    <div className="flex flex-col items-center justify-center gap-3 py-20">
+      <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      <p className="text-sm text-muted-foreground">로그인 처리 중...</p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- OAuthCallbackPage: 카카오 인가 코드 → JWT 토큰 교환 → 로그인 → 메인 리다이렉트
- StrictMode 이중 호출 방지 (useRef)
- code 누락 및 API 실패 시 안전한 폴백