### PR TITLE
feat: 찜목록 및 알람 페이지

### DIFF
--- a/frontend/src/components/bookmark/BookmarkCard.tsx
+++ b/frontend/src/components/bookmark/BookmarkCard.tsx
@@ -1,0 +1,102 @@
+import { Link } from 'react-router-dom'
+import { Calendar, MapPin, FileText, Bell, Pencil } from 'lucide-react'
+import type { MyBookmark } from '@/types/bookmark'
+
+function formatDate(dateStr: string) {
+  if (dateStr.length !== 8) return dateStr
+  return `${dateStr.slice(0, 4)}.${dateStr.slice(4, 6)}.${dateStr.slice(6, 8)}`
+}
+
+interface BookmarkCardProps {
+  bookmark: MyBookmark
+  onEdit: (bookmark: MyBookmark) => void
+}
+
+export default function BookmarkCard({ bookmark, onEdit }: BookmarkCardProps) {
+  const {
+    mt20id,
+    poster,
+    prfnm,
+    genrenm,
+    fcltynm,
+    stdate,
+    eddate,
+    reservationDate,
+    content,
+    alarm,
+  } = bookmark
+
+  return (
+    <div className="flex gap-4 rounded-xl border border-border bg-card p-4 transition-all hover:shadow-md">
+      <Link
+        to={`/performances/${mt20id}`}
+        state={{ performance: bookmark }}
+        className="shrink-0"
+      >
+        <div className="h-32 w-24 overflow-hidden rounded-lg bg-muted">
+          <img
+            src={poster}
+            alt={prfnm}
+            className="h-full w-full object-cover"
+            loading="lazy"
+            onError={(e) => {
+              e.currentTarget.src = `https://placehold.co/96x128/1a1a2e/e94560?text=${encodeURIComponent(prfnm.slice(0, 2))}`
+            }}
+          />
+        </div>
+      </Link>
+
+      <div className="flex flex-1 flex-col justify-between">
+        <div className="space-y-1.5">
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                {genrenm}
+              </span>
+              <h3 className="mt-1 text-sm font-semibold text-card-foreground line-clamp-1">
+                {prfnm}
+              </h3>
+            </div>
+            <button
+              onClick={() => onEdit(bookmark)}
+              className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+              title="수정"
+            >
+              <Pencil className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <MapPin className="h-3 w-3 shrink-0" />
+            <span className="line-clamp-1">{fcltynm}</span>
+          </div>
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <Calendar className="h-3 w-3 shrink-0" />
+            <span>{formatDate(stdate)} ~ {formatDate(eddate)}</span>
+          </div>
+        </div>
+
+        <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          {reservationDate && (
+            <span className="inline-flex items-center gap-1 rounded-md bg-accent px-2 py-0.5">
+              <Calendar className="h-3 w-3" />
+              예약: {formatDate(reservationDate)}
+            </span>
+          )}
+          {content && (
+            <span className="inline-flex items-center gap-1" title={content}>
+              <FileText className="h-3 w-3" />
+              메모
+            </span>
+          )}
+          {alarm && (
+            <span className="inline-flex items-center gap-1">
+              <Bell className="h-3 w-3" />
+              알람 설정됨
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/bookmark/BookmarkEditModal.tsx
+++ b/frontend/src/components/bookmark/BookmarkEditModal.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import { X } from 'lucide-react'
+import type { MyBookmark } from '@/types/bookmark'
+import { useEditBookmark } from '@/hooks/useBookmarks'
+
+interface BookmarkEditModalProps {
+  bookmark: MyBookmark
+  onClose: () => void
+}
+
+function parseReservationDate(dateStr: string) {
+  if (dateStr.length !== 8) return { year: 0, month: 0, day: 0 }
+  return {
+    year: parseInt(dateStr.slice(0, 4)),
+    month: parseInt(dateStr.slice(4, 6)),
+    day: parseInt(dateStr.slice(6, 8)),
+  }
+}
+
+export default function BookmarkEditModal({ bookmark, onClose }: BookmarkEditModalProps) {
+  const [content, setContent] = useState(bookmark.content)
+  const [alarm, setAlarm] = useState(bookmark.alarm)
+  const editMutation = useEditBookmark()
+
+  const handleSave = () => {
+    const { year, month, day } = parseReservationDate(bookmark.reservationDate)
+    if (year === 0) return
+
+    editMutation.mutate(
+      {
+        mt20id: bookmark.mt20id,
+        year,
+        month,
+        day,
+        body: { content, alarm },
+      },
+      {
+        onSuccess: () => onClose(),
+      },
+    )
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="mx-4 w-full max-w-md rounded-xl border border-border bg-card p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold">찜 수정</h2>
+          <button
+            onClick={onClose}
+            className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <p className="mb-4 text-sm font-medium text-foreground">{bookmark.prfnm}</p>
+
+        <div className="space-y-4">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-foreground">메모</label>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="메모를 입력하세요"
+              rows={3}
+              className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none transition-colors focus:border-primary focus:ring-1 focus:ring-ring resize-none"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-foreground">
+              알람 날짜 (yyyyMMdd, 쉼표 구분)
+            </label>
+            <input
+              type="text"
+              value={alarm}
+              onChange={(e) => setAlarm(e.target.value)}
+              placeholder="20260314,20260312"
+              className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none transition-colors focus:border-primary focus:ring-1 focus:ring-ring"
+            />
+          </div>
+        </div>
+
+        <div className="mt-6 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={editMutation.isPending}
+            className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+          >
+            {editMutation.isPending ? '저장 중...' : '저장'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useBookmarks.ts
+++ b/frontend/src/hooks/useBookmarks.ts
@@ -1,0 +1,53 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getBookmarks, toggleBookmark, editBookmark } from '@/api/bookmark'
+import { mockBookmarks } from '@/mocks/bookmarks'
+import type { EditBookmarkRequest } from '@/types/bookmark'
+
+const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true'
+
+export function useBookmarks() {
+  return useQuery({
+    queryKey: ['bookmarks'],
+    queryFn: async () => {
+      if (USE_MOCK) return mockBookmarks
+      try {
+        return await getBookmarks()
+      } catch {
+        return mockBookmarks
+      }
+    },
+  })
+}
+
+export function useToggleBookmark() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ mt20id, year, month, day }: { mt20id: string; year: number; month: number; day: number }) =>
+      toggleBookmark(mt20id, year, month, day),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['bookmarks'] })
+    },
+  })
+}
+
+export function useEditBookmark() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      mt20id,
+      year,
+      month,
+      day,
+      body,
+    }: {
+      mt20id: string
+      year: number
+      month: number
+      day: number
+      body: EditBookmarkRequest
+    }) => editBookmark(mt20id, year, month, day, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['bookmarks'] })
+    },
+  })
+}

--- a/frontend/src/pages/AlarmPage.tsx
+++ b/frontend/src/pages/AlarmPage.tsx
@@ -1,7 +1,49 @@
+import { useQuery } from '@tanstack/react-query'
+import { getAlarms } from '@/api/user'
+import ErrorFallback from '@/components/common/ErrorFallback'
+import { Bell, Loader2 } from 'lucide-react'
+
 export default function AlarmPage() {
+  const {
+    data: alarms,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: ['alarms'],
+    queryFn: getAlarms,
+  })
+
   return (
-    <div className="flex items-center justify-center min-h-[60vh]">
-      <h1 className="text-2xl font-bold text-foreground">알람</h1>
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <Bell className="h-5 w-5 text-primary" />
+        <h1 className="text-xl font-bold">알람</h1>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : isError ? (
+        <ErrorFallback message="알람을 불러올 수 없습니다." onRetry={() => refetch()} />
+      ) : alarms && alarms.length > 0 ? (
+        <div className="space-y-3">
+          {alarms.map((alarm, index) => (
+            <div
+              key={index}
+              className="rounded-lg border border-border bg-card p-4 text-sm text-card-foreground"
+            >
+              {typeof alarm === 'string' ? alarm : JSON.stringify(alarm)}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center gap-3 py-20">
+          <Bell className="h-12 w-12 text-muted-foreground/50" />
+          <p className="text-muted-foreground">설정된 알람이 없습니다.</p>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/BookmarkPage.tsx
+++ b/frontend/src/pages/BookmarkPage.tsx
@@ -1,7 +1,48 @@
+import { useState } from 'react'
+import { useBookmarks } from '@/hooks/useBookmarks'
+import BookmarkCard from '@/components/bookmark/BookmarkCard'
+import BookmarkEditModal from '@/components/bookmark/BookmarkEditModal'
+import ErrorFallback from '@/components/common/ErrorFallback'
+import type { MyBookmark } from '@/types/bookmark'
+import { Bookmark, Loader2 } from 'lucide-react'
+
 export default function BookmarkPage() {
+  const { data: bookmarks, isLoading, isError, refetch } = useBookmarks()
+  const [editTarget, setEditTarget] = useState<MyBookmark | null>(null)
+
   return (
-    <div className="flex items-center justify-center min-h-[60vh]">
-      <h1 className="text-2xl font-bold text-foreground">찜목록</h1>
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <Bookmark className="h-5 w-5 text-primary" />
+        <h1 className="text-xl font-bold">찜목록</h1>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : isError ? (
+        <ErrorFallback message="찜목록을 불러올 수 없습니다." onRetry={() => refetch()} />
+      ) : bookmarks && bookmarks.length > 0 ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          {bookmarks.map((bookmark) => (
+            <BookmarkCard
+              key={`${bookmark.mt20id}-${bookmark.reservationDate}`}
+              bookmark={bookmark}
+              onEdit={setEditTarget}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center gap-3 py-20">
+          <Bookmark className="h-12 w-12 text-muted-foreground/50" />
+          <p className="text-muted-foreground">찜한 공연이 없습니다.</p>
+        </div>
+      )}
+
+      {editTarget && (
+        <BookmarkEditModal bookmark={editTarget} onClose={() => setEditTarget(null)} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- useBookmarks/useToggleBookmark/useEditBookmark 훅 (TanStack Query mutation + 자동 리페치)
- BookmarkCard: 포스터 썸네일, 공연 정보, 예약일/메모/알람 배지, 수정 버튼
- BookmarkEditModal: 메모/알람 수정, 저장 시 API 호출 + 목록 갱신
- BookmarkPage: 2열 카드 그리드, 빈/로딩/에러 상태 처리
- AlarmPage: 알람 목록 조회 및 표시