### PR TITLE
feat: Dev 로그인 엔드포인트 추가

### DIFF
--- a/src/main/java/com/example/calenduck/domain/user/controller/DevLoginController.java
+++ b/src/main/java/com/example/calenduck/domain/user/controller/DevLoginController.java
@@ -1,0 +1,44 @@
+package com.example.calenduck.domain.user.controller;
+
+import com.example.calenduck.domain.user.dto.request.KakaoUserInfoDto;
+import com.example.calenduck.domain.user.entity.User;
+import com.example.calenduck.domain.user.entity.UserRoleEnum;
+import com.example.calenduck.domain.user.repository.UserRepository;
+import com.example.calenduck.global.jwt.JwtUtil;
+import com.example.calenduck.global.message.ResponseMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+
+@Profile("db-local")
+@RestController
+@RequiredArgsConstructor
+public class DevLoginController {
+
+    private static final Long DEV_KAKAO_ID = 99999L;
+    private static final String DEV_NICKNAME = "dev-user";
+    private static final String DEV_EMAIL = "dev@test.com";
+
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/dev/login")
+    public ResponseEntity<?> devLogin(HttpServletResponse response) {
+        User user = userRepository.findByKakaoId(DEV_KAKAO_ID)
+                .orElseGet(() -> userRepository.save(
+                        new User(
+                                new KakaoUserInfoDto(DEV_KAKAO_ID, DEV_NICKNAME, DEV_EMAIL, null, null),
+                                UserRoleEnum.USER
+                        )
+                ));
+
+        String token = jwtUtil.createToken(user.getNickname(), user.getKakaoEmail(), user.getRole());
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, token);
+
+        return ResponseMessage.SuccessResponse("Dev 로그인 성공", "");
+    }
+}


### PR DESCRIPTION
## Summary
- @Profile("db-local") 전용 `POST /dev/login` 엔드포인트 추가
- kakaoId=99999 테스트 유저를 자동 생성하고 JWT를 발급
- 프로덕션 환경에서는 Bean 자체가 생성되지 않음

## Test plan
- [ ] db-local 프로필로 서버 실행 후 `POST /dev/login` 호출
- [ ] Authorization 헤더에 JWT 토큰 반환 확인
- [ ] 발급된 토큰으로 인증 필요 API 정상 접근 확인