### PR TITLE
fix: spring-dotenv 제거, Spring config import 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,6 @@ dependencies {
 	// AOP (Resilience4j 어노테이션 동작에 필수)
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
-	// dotenv (.env 파일에서 환경변수 로드)
-	implementation 'me.paulschwarz:spring-dotenv:2.5.4'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 # ===== Profile =====
 spring:
+  config:
+    import: optional:file:.env[.properties]
   profiles:
     active: db-local
 


### PR DESCRIPTION
## Summary
- spring-dotenv 라이브러리 의존성 제거
- spring.config.import로 .env 파일을 직접 로드하도록 변경

## 변경 파일
- build.gradle — spring-dotenv 의존성 제거
- application.yml — spring.config.import 추가