### PR TITLE
feat: 캘린더 페이지 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import SearchPage from '@/pages/SearchPage'
 import PerformanceDetailPage from '@/pages/PerformanceDetailPage'
 import RankingPage from '@/pages/RankingPage'
 import BookmarkPage from '@/pages/BookmarkPage'
+import CalendarPage from '@/pages/CalendarPage'
 import AlarmPage from '@/pages/AlarmPage'
 import OAuthCallbackPage from '@/pages/OAuthCallbackPage'
 
@@ -27,6 +28,14 @@ export default function App() {
               element={
                 <ProtectedRoute>
                   <BookmarkPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/calendar"
+              element={
+                <ProtectedRoute>
+                  <CalendarPage />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/components/calendar/CalendarDayCell.tsx
+++ b/frontend/src/components/calendar/CalendarDayCell.tsx
@@ -1,0 +1,56 @@
+interface CalendarDayCellProps {
+  day: number
+  isToday: boolean
+  isSelected: boolean
+  hasBookmarks: boolean
+  bookmarkCount: number
+  dayOfWeek: number
+  onClick: () => void
+}
+
+export default function CalendarDayCell({
+  day,
+  isToday,
+  isSelected,
+  hasBookmarks,
+  bookmarkCount,
+  dayOfWeek,
+  onClick,
+}: CalendarDayCellProps) {
+  const isSunday = dayOfWeek === 0
+  const isSaturday = dayOfWeek === 6
+
+  const baseClass = 'flex aspect-square flex-col items-center justify-center gap-1 rounded-xl text-sm font-medium cursor-pointer transition-all'
+
+  let stateClass: string
+  if (isToday && isSelected) {
+    stateClass = 'bg-gradient-to-br from-primary to-coral text-white shadow-md ring-2 ring-primary/30'
+  } else if (isToday) {
+    stateClass = 'bg-gradient-to-br from-primary to-coral text-white shadow-sm'
+  } else if (isSelected) {
+    stateClass = 'bg-primary/10 text-primary ring-2 ring-primary/30'
+  } else {
+    const weekendColor = isSunday ? 'text-coral' : isSaturday ? 'text-primary' : 'text-foreground'
+    stateClass = `${weekendColor} hover:bg-primary/5`
+  }
+
+  const dotCount = Math.min(bookmarkCount, 3)
+
+  return (
+    <button className={`${baseClass} ${stateClass}`} onClick={onClick}>
+      <span>{day}</span>
+      {hasBookmarks && (
+        <div className="flex gap-0.5">
+          {Array.from({ length: dotCount }).map((_, i) => (
+            <span
+              key={i}
+              className={`h-1.5 w-1.5 rounded-full ${
+                isToday ? 'bg-white/80' : 'bg-primary'
+              }`}
+            />
+          ))}
+        </div>
+      )}
+    </button>
+  )
+}

--- a/frontend/src/components/calendar/CalendarDayDetail.tsx
+++ b/frontend/src/components/calendar/CalendarDayDetail.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import { CalendarDays } from 'lucide-react'
+import type { MyBookmark } from '@/types/bookmark'
+import { parseDateKey } from '@/hooks/useCalendar'
+import BookmarkCard from '@/components/bookmark/BookmarkCard'
+import BookmarkEditModal from '@/components/bookmark/BookmarkEditModal'
+
+const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토']
+
+interface CalendarDayDetailProps {
+  date: string
+  bookmarks: MyBookmark[]
+}
+
+export default function CalendarDayDetail({ date, bookmarks }: CalendarDayDetailProps) {
+  const [editTarget, setEditTarget] = useState<MyBookmark | null>(null)
+  const { year, month, day } = parseDateKey(date)
+  const dayOfWeek = new Date(year, month - 1, day).getDay()
+  const label = `${month}월 ${day}일 ${DAY_NAMES[dayOfWeek]}요일`
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-bold text-foreground">{label}</h2>
+        {bookmarks.length > 0 && (
+          <span className="rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-semibold text-primary">
+            {bookmarks.length}건
+          </span>
+        )}
+      </div>
+
+      {bookmarks.length > 0 ? (
+        <div className="space-y-3">
+          {bookmarks.map((bookmark) => (
+            <BookmarkCard
+              key={`${bookmark.mt20id}-${bookmark.reservationDate}`}
+              bookmark={bookmark}
+              onEdit={setEditTarget}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center gap-2 rounded-2xl border border-border/60 bg-card py-12 shadow-sm">
+          <CalendarDays className="h-10 w-10 text-muted-foreground/40" />
+          <p className="text-sm text-muted-foreground">이 날짜에 찜한 공연이 없습니다.</p>
+        </div>
+      )}
+
+      {editTarget && (
+        <BookmarkEditModal bookmark={editTarget} onClose={() => setEditTarget(null)} />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/calendar/CalendarGrid.tsx
+++ b/frontend/src/components/calendar/CalendarGrid.tsx
@@ -1,0 +1,68 @@
+import type { MyBookmark } from '@/types/bookmark'
+import { getDaysInMonth, getFirstDayOfWeek, formatDateKey } from '@/hooks/useCalendar'
+import CalendarDayCell from './CalendarDayCell'
+
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토']
+
+interface CalendarGridProps {
+  year: number
+  month: number
+  bookmarksByDate: Map<string, MyBookmark[]>
+  selectedDate: string | null
+  onSelectDate: (dateKey: string) => void
+}
+
+export default function CalendarGrid({
+  year,
+  month,
+  bookmarksByDate,
+  selectedDate,
+  onSelectDate,
+}: CalendarGridProps) {
+  const daysInMonth = getDaysInMonth(year, month)
+  const firstDay = getFirstDayOfWeek(year, month)
+
+  const today = new Date()
+  const todayKey = formatDateKey(today.getFullYear(), today.getMonth() + 1, today.getDate())
+
+  return (
+    <div className="rounded-2xl border border-border/60 bg-card p-4 shadow-sm">
+      <div className="grid grid-cols-7 gap-1">
+        {WEEKDAYS.map((day, i) => (
+          <div
+            key={day}
+            className={`py-2 text-center text-xs font-semibold ${
+              i === 0 ? 'text-coral' : i === 6 ? 'text-primary' : 'text-muted-foreground'
+            }`}
+          >
+            {day}
+          </div>
+        ))}
+
+        {Array.from({ length: firstDay }).map((_, i) => (
+          <div key={`empty-${i}`} />
+        ))}
+
+        {Array.from({ length: daysInMonth }).map((_, i) => {
+          const day = i + 1
+          const dateKey = formatDateKey(year, month, day)
+          const dayOfWeek = (firstDay + i) % 7
+          const bookmarks = bookmarksByDate.get(dateKey)
+
+          return (
+            <CalendarDayCell
+              key={day}
+              day={day}
+              isToday={dateKey === todayKey}
+              isSelected={dateKey === selectedDate}
+              hasBookmarks={!!bookmarks}
+              bookmarkCount={bookmarks?.length ?? 0}
+              dayOfWeek={dayOfWeek}
+              onClick={() => onSelectDate(dateKey)}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/calendar/CalendarHeader.tsx
+++ b/frontend/src/components/calendar/CalendarHeader.tsx
@@ -1,0 +1,47 @@
+import { ChevronLeft, ChevronRight, CalendarDays } from 'lucide-react'
+
+interface CalendarHeaderProps {
+  year: number
+  month: number
+  onPrevMonth: () => void
+  onNextMonth: () => void
+  onToday: () => void
+}
+
+export default function CalendarHeader({
+  year,
+  month,
+  onPrevMonth,
+  onNextMonth,
+  onToday,
+}: CalendarHeaderProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <CalendarDays className="h-5 w-5 text-primary" />
+        <h1 className="text-xl font-bold">{year}년 {month}월</h1>
+      </div>
+
+      <div className="flex items-center gap-1">
+        <button
+          onClick={onToday}
+          className="rounded-lg px-3 py-1.5 text-xs font-semibold text-primary hover:bg-primary/10 transition-colors"
+        >
+          오늘
+        </button>
+        <button
+          onClick={onPrevMonth}
+          className="rounded-lg p-1.5 text-muted-foreground hover:bg-primary/10 hover:text-primary transition-colors"
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </button>
+        <button
+          onClick={onNextMonth}
+          className="rounded-lg p-1.5 text-muted-foreground hover:bg-primary/10 hover:text-primary transition-colors"
+        >
+          <ChevronRight className="h-5 w-5" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
-import { Bookmark, Bell, TrendingUp, LogOut } from 'lucide-react'
+import { Bookmark, Bell, TrendingUp, CalendarDays, LogOut } from 'lucide-react'
 import SearchBar from '@/components/common/SearchBar'
 import { devLogin } from '@/api/user'
 
@@ -38,6 +38,13 @@ export default function Header() {
 
           {isAuthenticated ? (
             <>
+              <Link
+                to="/calendar"
+                className="rounded-lg p-2 text-muted-foreground hover:bg-primary/10 hover:text-primary transition-colors"
+                title="캘린더"
+              >
+                <CalendarDays className="h-5 w-5" />
+              </Link>
               <Link
                 to="/bookmarks"
                 className="rounded-lg p-2 text-muted-foreground hover:bg-primary/10 hover:text-primary transition-colors"

--- a/frontend/src/hooks/useCalendar.ts
+++ b/frontend/src/hooks/useCalendar.ts
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+
+export function getDaysInMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate()
+}
+
+export function getFirstDayOfWeek(year: number, month: number): number {
+  return new Date(year, month - 1, 1).getDay()
+}
+
+export function formatDateKey(year: number, month: number, day: number): string {
+  return `${year}${String(month).padStart(2, '0')}${String(day).padStart(2, '0')}`
+}
+
+export function parseDateKey(dateKey: string): { year: number; month: number; day: number } {
+  return {
+    year: parseInt(dateKey.slice(0, 4)),
+    month: parseInt(dateKey.slice(4, 6)),
+    day: parseInt(dateKey.slice(6, 8)),
+  }
+}
+
+export function useCalendar() {
+  const today = new Date()
+  const [year, setYear] = useState(today.getFullYear())
+  const [month, setMonth] = useState(today.getMonth() + 1)
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+
+  const goToPrevMonth = () => {
+    if (month === 1) {
+      setYear((y) => y - 1)
+      setMonth(12)
+    } else {
+      setMonth((m) => m - 1)
+    }
+    setSelectedDate(null)
+  }
+
+  const goToNextMonth = () => {
+    if (month === 12) {
+      setYear((y) => y + 1)
+      setMonth(1)
+    } else {
+      setMonth((m) => m + 1)
+    }
+    setSelectedDate(null)
+  }
+
+  const goToToday = () => {
+    const now = new Date()
+    setYear(now.getFullYear())
+    setMonth(now.getMonth() + 1)
+    setSelectedDate(formatDateKey(now.getFullYear(), now.getMonth() + 1, now.getDate()))
+  }
+
+  return { year, month, selectedDate, setSelectedDate, goToPrevMonth, goToNextMonth, goToToday }
+}

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from 'react'
+import { useBookmarks } from '@/hooks/useBookmarks'
+import { useCalendar } from '@/hooks/useCalendar'
+import type { MyBookmark } from '@/types/bookmark'
+import CalendarHeader from '@/components/calendar/CalendarHeader'
+import CalendarGrid from '@/components/calendar/CalendarGrid'
+import CalendarDayDetail from '@/components/calendar/CalendarDayDetail'
+import ErrorFallback from '@/components/common/ErrorFallback'
+import { Loader2 } from 'lucide-react'
+
+export default function CalendarPage() {
+  const { data: bookmarks, isLoading, isError, refetch } = useBookmarks()
+  const { year, month, selectedDate, setSelectedDate, goToPrevMonth, goToNextMonth, goToToday } =
+    useCalendar()
+
+  const bookmarksByDate = useMemo(() => {
+    const map = new Map<string, MyBookmark[]>()
+    if (!bookmarks) return map
+    for (const bm of bookmarks) {
+      const key = bm.reservationDate
+      if (!key) continue
+      const existing = map.get(key)
+      if (existing) {
+        existing.push(bm)
+      } else {
+        map.set(key, [bm])
+      }
+    }
+    return map
+  }, [bookmarks])
+
+  const selectedBookmarks = selectedDate ? (bookmarksByDate.get(selectedDate) ?? []) : []
+
+  return (
+    <div className="space-y-6">
+      <CalendarHeader
+        year={year}
+        month={month}
+        onPrevMonth={goToPrevMonth}
+        onNextMonth={goToNextMonth}
+        onToday={goToToday}
+      />
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      ) : isError ? (
+        <ErrorFallback message="북마크를 불러올 수 없습니다." onRetry={() => refetch()} />
+      ) : (
+        <>
+          <CalendarGrid
+            year={year}
+            month={month}
+            bookmarksByDate={bookmarksByDate}
+            selectedDate={selectedDate}
+            onSelectDate={setSelectedDate}
+          />
+          {selectedDate && (
+            <CalendarDayDetail date={selectedDate} bookmarks={selectedBookmarks} />
+          )}
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- 월간 캘린더 뷰 구현 (커스텀 7칼럼 CSS grid, 외부 라이브러리 없음)
- 찜목록을 reservationDate 기준으로 날짜별 그룹핑하여 캘린더에 dot 표시
- 날짜 클릭 시 인라인 상세 패널에 BookmarkCard 재사용하여 해당 날짜 북마크 표시
- 월 이동 (이전/다음), 오늘 버튼, today 하이라이트
- Header에 CalendarDays 아이콘 네비 추가, /calendar 라우트 (ProtectedRoute)

## 변경사항
- 신규: useCalendar hook, CalendarHeader, CalendarGrid, CalendarDayCell, CalendarDayDetail, CalendarPage
- 수정: App.tsx (라우트), Header.tsx (네비)