### PR TITLE
fix: 검색 필터 AND→OR 수정 및 캐시 활용 성능 개선

### DIFF
--- a/src/main/java/com/example/calenduck/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/PerformanceService.java
@@ -5,15 +5,16 @@ import com.example.calenduck.domain.performance.http.BatchManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.select.Elements;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachePut;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
-import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -22,31 +23,26 @@ public class PerformanceService implements PerformanceServiceBehavior {
 
     private final PerformanceSearchBehavior performanceSearchService;
     private final BatchManager batchManager;
+    private final CacheManager cacheManager;
 
-    // 전체 조회 & 메인 & 검색
+    private static final String CACHE_NAME = "elementsCache";
+    private static final String CACHE_KEY = "getAllPerformances";
+
     @Override
-    @Transactional
-    @Cacheable(value = "elementsCache",
-            condition = "#prfnm == null and #prfcast == null",
-            key = "#root.methodName",
-            unless = "#result.isEmpty()")
     public List<BasePerformancesResponseDto> getAllPerformances(String prfnm, String prfcast) throws ExecutionException, InterruptedException {
-        try {
-            List<Elements> elements = batchManager.getElements();
-            String lowerPrfnm = searchPerformanceNullCheck(prfnm);
-            String lowerPrfcast = searchCastNullCheck(prfcast);
-            List<BasePerformancesResponseDto> performances = savePerformanceInformation(elements, lowerPrfnm, lowerPrfcast);
+        List<BasePerformancesResponseDto> allPerformances = getOrLoadAllPerformances();
 
-            updateSearchWord(prfnm, prfcast);
-            return performances;
-        } catch (ExecutionException e) {
-            log.error("실행 에러 발생", e);
-            throw e;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("스레드 중단됨", e);
-            throw e;
+        if (prfnm == null && prfcast == null) {
+            return allPerformances;
         }
+
+        String lowerPrfnm = prfnm != null ? prfnm.toLowerCase() : null;
+        String lowerPrfcast = prfcast != null ? prfcast.toLowerCase() : null;
+        updateSearchWord(prfnm, prfcast);
+
+        return allPerformances.stream()
+                .filter(dto -> isMatch(lowerPrfnm, lowerPrfcast, dto))
+                .collect(Collectors.toList());
     }
 
     // 스케줄러용 캐시 갱신 메서드
@@ -57,24 +53,43 @@ public class PerformanceService implements PerformanceServiceBehavior {
     public List<BasePerformancesResponseDto> refreshPerformancesCache() {
         try {
             List<Elements> elements = batchManager.getElements();
-            return savePerformanceInformation(elements, null, null);
+            return convertAllToDto(elements);
         } catch (Exception e) {
             log.error("캐시 갱신 중 KOPIS API 호출 실패", e);
             return Collections.emptyList();
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private List<BasePerformancesResponseDto> getOrLoadAllPerformances() throws ExecutionException, InterruptedException {
+        Cache cache = cacheManager.getCache(CACHE_NAME);
+        if (cache != null) {
+            Cache.ValueWrapper cached = cache.get(CACHE_KEY);
+            if (cached != null) {
+                return (List<BasePerformancesResponseDto>) cached.get();
+            }
+        }
+
+        try {
+            List<Elements> elements = batchManager.getElements();
+            List<BasePerformancesResponseDto> result = convertAllToDto(elements);
+            if (!result.isEmpty() && cache != null) {
+                cache.put(CACHE_KEY, result);
+            }
+            return result;
+        } catch (ExecutionException e) {
+            log.error("실행 에러 발생", e);
+            throw e;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("스레드 중단됨", e);
+            throw e;
+        }
+    }
+
     private void updateSearchWord(String prfnm, String prfcast) {
         if (prfnm != null) performanceSearchService.updatePopularSearchWord(prfnm);
         if (prfcast != null) performanceSearchService.updatePopularSearchWord(prfcast);
-    }
-
-    private String searchPerformanceNullCheck(String prfnm) {
-        return prfnm != null ? prfnm.toLowerCase() : null;
-    }
-
-    private String searchCastNullCheck(String prfcast) {
-        return prfcast != null ? prfcast.toLowerCase() : null;
     }
 
     private BasePerformancesResponseDto createPerformanceDto(Elements element) {
@@ -93,18 +108,19 @@ public class PerformanceService implements PerformanceServiceBehavior {
     }
 
     private boolean isMatch(String lowerPrfnm, String lowerPrfcast, BasePerformancesResponseDto dto) {
-        return (lowerPrfnm == null || dto.getPrfnm().toLowerCase().contains(lowerPrfnm))
-                && (lowerPrfcast == null || dto.getPrfcast().toLowerCase().contains(lowerPrfcast));
+        if (lowerPrfnm == null && lowerPrfcast == null) {
+            return true;
+        }
+
+        boolean nameMatch = lowerPrfnm != null && dto.getPrfnm().toLowerCase().contains(lowerPrfnm);
+        boolean castMatch = lowerPrfcast != null && dto.getPrfcast().toLowerCase().contains(lowerPrfcast);
+        return nameMatch || castMatch;
     }
 
-    private List<BasePerformancesResponseDto> savePerformanceInformation(List<Elements> elements, String lowerPrfnm, String lowerPrfcast) {
+    private List<BasePerformancesResponseDto> convertAllToDto(List<Elements> elements) {
         List<BasePerformancesResponseDto> performances = new ArrayList<>();
-
         for (Elements element : elements) {
-            BasePerformancesResponseDto dto = createPerformanceDto(element);
-            if (isMatch(lowerPrfnm, lowerPrfcast, dto)) {
-                performances.add(dto);
-            }
+            performances.add(createPerformanceDto(element));
         }
         return performances;
     }

--- a/src/test/java/com/example/calenduck/domain/performance/service/PerformanceServiceSearchTest.java
+++ b/src/test/java/com/example/calenduck/domain/performance/service/PerformanceServiceSearchTest.java
@@ -1,0 +1,158 @@
+package com.example.calenduck.domain.performance.service;
+
+import com.example.calenduck.domain.performance.dto.response.BasePerformancesResponseDto;
+import com.example.calenduck.domain.performance.http.BatchManager;
+import org.jsoup.Jsoup;
+import org.jsoup.select.Elements;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PerformanceServiceSearchTest {
+
+    @Mock
+    private PerformanceSearchBehavior performanceSearchService;
+
+    @Mock
+    private BatchManager batchManager;
+
+    @Mock
+    private CacheManager cacheManager;
+
+    @Mock
+    private Cache cache;
+
+    private PerformanceService performanceService;
+
+    private Elements createTestElements(String mt20id, String prfnm, String prfcast) {
+        String xml = String.format(
+                "<db><mt20id>%s</mt20id><poster>poster.jpg</poster><prfnm>%s</prfnm>"
+                        + "<prfcast>%s</prfcast><genrenm>뮤지컬</genrenm><fcltynm>극장</fcltynm>"
+                        + "<dtguidance>19:30</dtguidance><prfpdfrom>2024.01.01</prfpdfrom>"
+                        + "<prfpdto>2024.03.01</prfpdto><pcseguidance>50000원</pcseguidance></db>",
+                mt20id, prfnm, prfcast);
+        return Jsoup.parse(xml).select("db > *");
+    }
+
+    private List<BasePerformancesResponseDto> cachedPerformances() {
+        return Arrays.asList(
+                new BasePerformancesResponseDto("PF001", "poster1.jpg", "뮤지컬 캣츠", "배우A, 배우C", "뮤지컬", "극장1", "19:30", "2024.01.01", "2024.03.01", "50000원"),
+                new BasePerformancesResponseDto("PF002", "poster2.jpg", "오페라의 유령", "배우B", "뮤지컬", "극장2", "19:30", "2024.01.01", "2024.03.01", "60000원"),
+                new BasePerformancesResponseDto("PF003", "poster3.jpg", "링크드 콘서트", "배우D", "콘서트", "극장3", "20:00", "2024.02.01", "2024.04.01", "70000원")
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+        performanceService = new PerformanceService(performanceSearchService, batchManager, cacheManager);
+    }
+
+    @Nested
+    @DisplayName("검색 필터링 로직")
+    class SearchFiltering {
+
+        @BeforeEach
+        void setUpCache() {
+            when(cacheManager.getCache("elementsCache")).thenReturn(cache);
+            when(cache.get("getAllPerformances")).thenReturn(() -> cachedPerformances());
+        }
+
+        @Test
+        @DisplayName("공연명으로 검색 시 공연명에 검색어가 포함된 공연을 반환한다")
+        void searchByName_returnsMatchingByName() throws Exception {
+            List<BasePerformancesResponseDto> result = performanceService.getAllPerformances("캣츠", null);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getPrfnm()).contains("캣츠");
+        }
+
+        @Test
+        @DisplayName("출연진으로 검색 시 출연진에 검색어가 포함된 공연을 반환한다")
+        void searchByCast_returnsMatchingByCast() throws Exception {
+            List<BasePerformancesResponseDto> result = performanceService.getAllPerformances(null, "배우B");
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getPrfcast()).contains("배우B");
+        }
+
+        @Test
+        @DisplayName("공연명과 출연진 동시 검색 시 OR 조건으로 매칭한다")
+        void searchByBoth_returnsMatchingEither() throws Exception {
+            // "캣츠"는 PF001 공연명에, "배우B"는 PF002 출연진에 매칭
+            List<BasePerformancesResponseDto> result = performanceService.getAllPerformances("캣츠", "배우B");
+
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(BasePerformancesResponseDto::getMt20id)
+                    .containsExactlyInAnyOrder("PF001", "PF002");
+        }
+
+        @Test
+        @DisplayName("검색어와 일치하는 공연이 없으면 빈 리스트를 반환한다")
+        void searchNoMatch_returnsEmptyList() throws Exception {
+            List<BasePerformancesResponseDto> result = performanceService.getAllPerformances("존재하지않는공연", null);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("검색은 대소문자를 구분하지 않는다")
+        void searchIsCaseInsensitive() throws Exception {
+            List<BasePerformancesResponseDto> result = performanceService.getAllPerformances("링크드", null);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getMt20id()).isEqualTo("PF003");
+        }
+
+        @Test
+        @DisplayName("검색 시 검색어를 인기검색어에 반영한다")
+        void search_updatesPopularSearchWord() throws Exception {
+            performanceService.getAllPerformances("캣츠", null);
+
+            verify(performanceSearchService).updatePopularSearchWord("캣츠");
+        }
+    }
+
+    @Nested
+    @DisplayName("검색 시 캐시 활용")
+    class SearchCacheUsage {
+
+        @Test
+        @DisplayName("캐시에 데이터가 있으면 BatchManager를 호출하지 않는다")
+        void search_withCachedData_doesNotCallBatchManager() throws Exception {
+            when(cacheManager.getCache("elementsCache")).thenReturn(cache);
+            when(cache.get("getAllPerformances")).thenReturn(() -> cachedPerformances());
+
+            performanceService.getAllPerformances("캣츠", null);
+
+            verify(batchManager, never()).getElements();
+        }
+
+        @Test
+        @DisplayName("캐시가 비어있으면 BatchManager를 호출하여 데이터를 로드한다")
+        void search_withEmptyCache_callsBatchManager() throws Exception {
+            when(cacheManager.getCache("elementsCache")).thenReturn(cache);
+            when(cache.get("getAllPerformances")).thenReturn(null);
+
+            Elements el1 = createTestElements("PF001", "뮤지컬 캣츠", "배우A");
+            when(batchManager.getElements()).thenReturn(Arrays.asList(el1));
+
+            List<BasePerformancesResponseDto> result = performanceService.getAllPerformances(null, null);
+
+            verify(batchManager).getElements();
+            assertThat(result).hasSize(1);
+        }
+    }
+}

--- a/src/test/java/com/example/calenduck/domain/performance/service/PerformanceServiceTest.java
+++ b/src/test/java/com/example/calenduck/domain/performance/service/PerformanceServiceTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,6 +29,12 @@ class PerformanceServiceTest {
     @Mock
     private BatchManager batchManager;
 
+    @Mock
+    private CacheManager cacheManager;
+
+    @Mock
+    private Cache cache;
+
     @InjectMocks
     private PerformanceService performanceService;
 
@@ -41,9 +49,12 @@ class PerformanceServiceTest {
     }
 
     @Test
-    @DisplayName("BatchManager 성공 시 전체 공연 목록을 반환한다")
-    void getAllPerformances_withElements_returnsPerformances() throws Exception {
+    @DisplayName("캐시 미스 시 BatchManager를 호출하여 전체 공연 목록을 반환한다")
+    void getAllPerformances_cacheMiss_returnsPerformances() throws Exception {
         // Given
+        when(cacheManager.getCache("elementsCache")).thenReturn(cache);
+        when(cache.get("getAllPerformances")).thenReturn(null);
+
         Elements elements1 = createTestElements("PF001", "뮤지컬 캣츠", "배우A");
         Elements elements2 = createTestElements("PF002", "오페라의 유령", "배우B");
         when(batchManager.getElements()).thenReturn(Arrays.asList(elements1, elements2));
@@ -59,6 +70,8 @@ class PerformanceServiceTest {
     @DisplayName("BatchManager가 빈 리스트를 반환하면 빈 리스트를 반환한다")
     void getAllPerformances_withEmptyElements_returnsEmptyList() throws Exception {
         // Given
+        when(cacheManager.getCache("elementsCache")).thenReturn(cache);
+        when(cache.get("getAllPerformances")).thenReturn(null);
         when(batchManager.getElements()).thenReturn(Collections.emptyList());
 
         // When


### PR DESCRIPTION
## Summary
- 검색 필터 isMatch() 조건을 AND에서 OR로 변경
- 검색 시 CacheManager 기반으로 변경하여 캐시된 전체 목록에서 인메모리 필터링
- 불필요한 @Transactional, @Cacheable condition 제거

## Test plan
- [x] 공연명/출연진 OR 조건 검색 테스트 6개 통과
- [x] 캐시 히트/미스 동작 테스트 통과
- [x] 기존 테스트 전체 통과