### PR TITLE
fix: 프론트엔드 mock 데이터 fallback 제거

### DIFF
--- a/frontend/src/hooks/useBookmarks.ts
+++ b/frontend/src/hooks/useBookmarks.ts
@@ -10,11 +10,7 @@ export function useBookmarks() {
     queryKey: ['bookmarks'],
     queryFn: async () => {
       if (USE_MOCK) return mockBookmarks
-      try {
-        return await getBookmarks()
-      } catch {
-        return mockBookmarks
-      }
+      return await getBookmarks()
     },
   })
 }

--- a/frontend/src/hooks/usePerformances.ts
+++ b/frontend/src/hooks/usePerformances.ts
@@ -9,12 +9,7 @@ export function usePerformances(prfnm?: string, prfcast?: string) {
     queryKey: ['performances', prfnm, prfcast],
     queryFn: async () => {
       if (USE_MOCK) return mockPerformances
-      try {
-        const data = await getPerformances(prfnm, prfcast)
-        return data.length > 0 ? data : mockPerformances
-      } catch {
-        return mockPerformances
-      }
+      return await getPerformances(prfnm, prfcast)
     },
     staleTime: 1000 * 60 * 10,
   })

--- a/frontend/src/hooks/useRanking.ts
+++ b/frontend/src/hooks/useRanking.ts
@@ -9,12 +9,7 @@ export function useTopTen() {
     queryKey: ['topTen'],
     queryFn: async () => {
       if (USE_MOCK) return mockTopTen
-      try {
-        const data = await getTopTen()
-        return data || mockTopTen
-      } catch {
-        return mockTopTen
-      }
+      return await getTopTen()
     },
     staleTime: 1000 * 60 * 30,
   })
@@ -25,12 +20,7 @@ export function usePopularityByRegion() {
     queryKey: ['popularityByRegion'],
     queryFn: async () => {
       if (USE_MOCK) return mockPopularityByRegion
-      try {
-        const data = await getPopularityByRegion()
-        return data || mockPopularityByRegion
-      } catch {
-        return mockPopularityByRegion
-      }
+      return await getPopularityByRegion()
     },
     staleTime: 1000 * 60 * 30,
   })
@@ -41,12 +31,7 @@ export function usePopularityByGenreRegion() {
     queryKey: ['popularityByGenreRegion'],
     queryFn: async () => {
       if (USE_MOCK) return mockPopularityByGenreRegion
-      try {
-        const data = await getPopularityByGenreRegion()
-        return data || mockPopularityByGenreRegion
-      } catch {
-        return mockPopularityByGenreRegion
-      }
+      return await getPopularityByGenreRegion()
     },
     staleTime: 1000 * 60 * 30,
   })

--- a/frontend/src/hooks/useSearchRank.ts
+++ b/frontend/src/hooks/useSearchRank.ts
@@ -9,12 +9,7 @@ export function useSearchRank() {
     queryKey: ['searchRank'],
     queryFn: async () => {
       if (USE_MOCK) return mockSearchRanks
-      try {
-        const data = await getSearchRank()
-        return data.length > 0 ? data : mockSearchRanks
-      } catch {
-        return mockSearchRanks
-      }
+      return await getSearchRank()
     },
     staleTime: 1000 * 60 * 5,
   })

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useTopTen, usePopularityByRegion, usePopularityByGenreRegion } from '@/hooks/useRanking'
+import ErrorFallback from '@/components/common/ErrorFallback'
 import { TrendingUp, Loader2, Trophy, MapPin, Music } from 'lucide-react'
 
 type Tab = 'topten' | 'region' | 'genre'
@@ -45,9 +46,10 @@ export default function RankingPage() {
 }
 
 function TopTenSection() {
-  const { data, isLoading } = useTopTen()
+  const { data, isLoading, isError, refetch } = useTopTen()
 
   if (isLoading) return <LoadingState />
+  if (isError) return <ErrorFallback message="TOP 10 데이터를 불러올 수 없습니다." onRetry={() => refetch()} />
   if (!data || !Array.isArray(data)) return null
 
   return (
@@ -90,9 +92,10 @@ function TopTenSection() {
 }
 
 function RegionSection() {
-  const { data, isLoading } = usePopularityByRegion()
+  const { data, isLoading, isError, refetch } = usePopularityByRegion()
 
   if (isLoading) return <LoadingState />
+  if (isError) return <ErrorFallback message="지역별 인기 데이터를 불러올 수 없습니다." onRetry={() => refetch()} />
   if (!data || !Array.isArray(data)) return null
 
   const maxCount = Math.max(...data.map((item: Record<string, unknown>) => (item.count || item.cnt || 0) as number))
@@ -123,9 +126,10 @@ function RegionSection() {
 }
 
 function GenreSection() {
-  const { data, isLoading } = usePopularityByGenreRegion()
+  const { data, isLoading, isError, refetch } = usePopularityByGenreRegion()
 
   if (isLoading) return <LoadingState />
+  if (isError) return <ErrorFallback message="장르별 인기 데이터를 불러올 수 없습니다." onRetry={() => refetch()} />
   if (!data || !Array.isArray(data)) return null
 
   return (


### PR DESCRIPTION
## Summary
- usePerformances, useBookmarks, useRanking, useSearchRank hooks에서 API 응답이 비어있거나 에러 발생 시 mock 데이터로 대체하던 패턴 제거
- 에러를 React Query의 isError 상태로 전파하여 각 페이지에서 ErrorFallback UI로 처리
- RankingPage 3개 섹션(TopTen, Region, Genre)에 ErrorFallback 에러 UI 추가
- USE_MOCK 환경변수 분기는 개발 편의를 위해 유지

## Test plan
- [ ] VITE_USE_MOCK=false 상태에서 백엔드 API 정상 응답 시 실제 데이터 표시 확인
- [ ] 백엔드 미실행 시 각 페이지에서 ErrorFallback UI 표시 확인
- [ ] 검색 결과 0건일 때 mock 데이터 대신 빈 결과 표시 확인
- [ ] VITE_USE_MOCK=true 상태에서 기존 mock 데이터 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)