### PR TITLE
feat: 공연 단건 조회 API 및 상세 페이지 연동

### DIFF
--- a/frontend/src/api/performance.ts
+++ b/frontend/src/api/performance.ts
@@ -12,6 +12,11 @@ export async function getPerformances(prfnm?: string, prfcast?: string) {
   return data.data
 }
 
+export async function getPerformanceById(mt20id: string) {
+  const { data } = await client.get<ApiResponse<Performance>>(`/performances/${mt20id}`)
+  return data.data
+}
+
 export async function getSearchRank() {
   const { data } = await client.get<ApiResponse<SearchRank[]>>('/performances/search/rank')
   return data.data

--- a/frontend/src/hooks/usePerformances.ts
+++ b/frontend/src/hooks/usePerformances.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { getPerformances } from '@/api/performance'
+import { getPerformances, getPerformanceById } from '@/api/performance'
 import { mockPerformances } from '@/mocks/performances'
 
 const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true'
@@ -11,6 +11,18 @@ export function usePerformances(prfnm?: string, prfcast?: string) {
       if (USE_MOCK) return mockPerformances
       return await getPerformances(prfnm, prfcast)
     },
+    staleTime: 1000 * 60 * 10,
+  })
+}
+
+export function usePerformanceDetail(mt20id: string | undefined) {
+  return useQuery({
+    queryKey: ['performance', mt20id],
+    queryFn: async () => {
+      if (USE_MOCK) return mockPerformances.find((p) => p.mt20id === mt20id) ?? null
+      return await getPerformanceById(mt20id!)
+    },
+    enabled: !!mt20id,
     staleTime: 1000 * 60 * 10,
   })
 }

--- a/frontend/src/pages/PerformanceDetailPage.tsx
+++ b/frontend/src/pages/PerformanceDetailPage.tsx
@@ -1,7 +1,9 @@
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
+import { usePerformanceDetail } from '@/hooks/usePerformances'
 import type { Performance } from '@/types/performance'
-import { ArrowLeft, Calendar, MapPin, Clock, Users, CreditCard, Bookmark } from 'lucide-react'
+import ErrorFallback from '@/components/common/ErrorFallback'
+import { ArrowLeft, Calendar, MapPin, Clock, Users, CreditCard, Bookmark, Loader2 } from 'lucide-react'
 import { useState } from 'react'
 import { toggleBookmark } from '@/api/bookmark'
 
@@ -17,9 +19,25 @@ export default function PerformanceDetailPage() {
   const { isAuthenticated } = useAuth()
   const [bookmarkMessage, setBookmarkMessage] = useState<string | null>(null)
 
-  const performance = (location.state as { performance?: Performance })?.performance
+  const statePerformance = (location.state as { performance?: Performance })?.performance
+  const { data: fetchedPerformance, isLoading, isError, refetch } = usePerformanceDetail(
+    statePerformance ? undefined : mt20id,
+  )
+
+  const performance = statePerformance ?? fetchedPerformance
+
+  if (isLoading && !statePerformance) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
 
   if (!performance) {
+    if (isError) {
+      return <ErrorFallback message="공연 정보를 불러올 수 없습니다." onRetry={() => refetch()} />
+    }
     return (
       <div className="flex flex-col items-center justify-center gap-4 py-20">
         <p className="text-muted-foreground">공연 정보를 찾을 수 없습니다.</p>

--- a/src/main/java/com/example/calenduck/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/com/example/calenduck/domain/performance/controller/PerformanceController.java
@@ -10,8 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
-import java.sql.SQLException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -29,9 +27,16 @@ public class PerformanceController {
     public ResponseEntity<?> getAllPerformances(
             @RequestParam(required = false) String prfnm,
             @RequestParam(required = false) String prfcast
-    ) throws SQLException, IOException, ExecutionException, InterruptedException {
+    ) throws ExecutionException, InterruptedException {
         List<BasePerformancesResponseDto> performances = performanceService.getAllPerformances(prfnm, prfcast);
         return ResponseMessage.SuccessResponse("전체 조회 완료", performances);
+    }
+
+    @Operation(summary = "공연 단건 조회", description = "mt20id로 공연 상세 정보 조회")
+    @GetMapping("/{mt20id}")
+    public ResponseEntity<?> getPerformanceById(@PathVariable String mt20id) throws ExecutionException, InterruptedException {
+        BasePerformancesResponseDto performance = performanceService.getPerformanceById(mt20id);
+        return ResponseMessage.SuccessResponse("공연 조회 완료", performance);
     }
 
     @Operation(summary = "인기검색어 TOP 5", description = "인기검색어 TOP 5")

--- a/src/main/java/com/example/calenduck/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/PerformanceService.java
@@ -10,6 +10,9 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.stereotype.Service;
 
+import com.example.calenduck.global.exception.GlobalErrorCode;
+import com.example.calenduck.global.exception.GlobalException;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -43,6 +46,15 @@ public class PerformanceService implements PerformanceServiceBehavior {
         return allPerformances.stream()
                 .filter(dto -> isMatch(lowerPrfnm, lowerPrfcast, dto))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public BasePerformancesResponseDto getPerformanceById(String mt20id) throws ExecutionException, InterruptedException {
+        List<BasePerformancesResponseDto> allPerformances = getOrLoadAllPerformances();
+        return allPerformances.stream()
+                .filter(dto -> mt20id.equals(dto.getMt20id()))
+                .findFirst()
+                .orElseThrow(() -> new GlobalException(GlobalErrorCode.NOT_FOUND_PERFORMANCE));
     }
 
     // 스케줄러용 캐시 갱신 메서드

--- a/src/main/java/com/example/calenduck/domain/performance/service/PerformanceServiceBehavior.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/PerformanceServiceBehavior.java
@@ -7,5 +7,6 @@ import java.util.concurrent.ExecutionException;
 
 public interface PerformanceServiceBehavior {
     List<BasePerformancesResponseDto> getAllPerformances(String prfnm, String prfcast) throws ExecutionException, InterruptedException;
+    BasePerformancesResponseDto getPerformanceById(String mt20id) throws ExecutionException, InterruptedException;
     List<BasePerformancesResponseDto> refreshPerformancesCache();
 }

--- a/src/test/java/com/example/calenduck/domain/performance/service/PerformanceServiceTest.java
+++ b/src/test/java/com/example/calenduck/domain/performance/service/PerformanceServiceTest.java
@@ -13,11 +13,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 
+import com.example.calenduck.global.exception.GlobalException;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -107,5 +110,56 @@ class PerformanceServiceTest {
 
         // Then
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("캐시에 데이터가 있을 때 mt20id로 공연을 조회한다")
+    void getPerformanceById_withCachedData_returnsPerformance() throws Exception {
+        // Given
+        List<BasePerformancesResponseDto> cached = Arrays.asList(
+                new BasePerformancesResponseDto("PF001", "poster1.jpg", "뮤지컬 캣츠", "배우A", "뮤지컬", "극장1", "19:30", "2024.01.01", "2024.03.01", "50000원"),
+                new BasePerformancesResponseDto("PF002", "poster2.jpg", "오페라의 유령", "배우B", "뮤지컬", "극장2", "19:30", "2024.01.01", "2024.03.01", "60000원")
+        );
+        when(cacheManager.getCache("elementsCache")).thenReturn(cache);
+        when(cache.get("getAllPerformances")).thenReturn(() -> cached);
+
+        // When
+        BasePerformancesResponseDto result = performanceService.getPerformanceById("PF001");
+
+        // Then
+        assertThat(result.getMt20id()).isEqualTo("PF001");
+        assertThat(result.getPrfnm()).isEqualTo("뮤지컬 캣츠");
+    }
+
+    @Test
+    @DisplayName("캐시에 없는 mt20id 조회 시 NOT_FOUND_PERFORMANCE 예외를 던진다")
+    void getPerformanceById_notFound_throwsException() throws Exception {
+        // Given
+        List<BasePerformancesResponseDto> cached = Arrays.asList(
+                new BasePerformancesResponseDto("PF001", "poster1.jpg", "뮤지컬 캣츠", "배우A", "뮤지컬", "극장1", "19:30", "2024.01.01", "2024.03.01", "50000원")
+        );
+        when(cacheManager.getCache("elementsCache")).thenReturn(cache);
+        when(cache.get("getAllPerformances")).thenReturn(() -> cached);
+
+        // When & Then
+        assertThatThrownBy(() -> performanceService.getPerformanceById("PF999"))
+                .isInstanceOf(GlobalException.class);
+    }
+
+    @Test
+    @DisplayName("캐시 미스 시 BatchManager에서 로드 후 mt20id로 조회한다")
+    void getPerformanceById_cacheMiss_loadsAndReturns() throws Exception {
+        // Given
+        when(cacheManager.getCache("elementsCache")).thenReturn(cache);
+        when(cache.get("getAllPerformances")).thenReturn(null);
+
+        Elements elements = createTestElements("PF001", "뮤지컬 캣츠", "배우A");
+        when(batchManager.getElements()).thenReturn(Arrays.asList(elements));
+
+        // When
+        BasePerformancesResponseDto result = performanceService.getPerformanceById("PF001");
+
+        // Then
+        assertThat(result.getMt20id()).isEqualTo("PF001");
     }
 }


### PR DESCRIPTION
## Summary
- `GET /performances/{mt20id}` 엔드포인트 추가 (캐시 우선 조회, 없으면 404)
- 프론트엔드 PerformanceDetailPage에서 직접 URL 접근/새로고침 시 API로 데이터 로드
- location.state가 있으면 즉시 사용, 없으면 API fallback

## Test plan
- [ ] 공연 목록에서 클릭하여 상세 페이지 정상 진입 확인 (기존 state 방식)
- [ ] 상세 페이지 URL 직접 접근 시 API 호출로 데이터 로드 확인
- [ ] 존재하지 않는 mt20id 접근 시 에러 UI 표시 확인
- [ ] 단위 테스트 3건 통과 확인 (`./gradlew test --tests "*.PerformanceServiceTest"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)