### PR TITLE
fix: Redis 실패 시 검색 결과 반환 차단 해결

### DIFF
--- a/src/main/java/com/example/calenduck/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/PerformanceService.java
@@ -100,8 +100,12 @@ public class PerformanceService implements PerformanceServiceBehavior {
     }
 
     private void updateSearchWord(String prfnm, String prfcast) {
-        if (prfnm != null) performanceSearchService.updatePopularSearchWord(prfnm);
-        if (prfcast != null) performanceSearchService.updatePopularSearchWord(prfcast);
+        try {
+            if (prfnm != null) performanceSearchService.updatePopularSearchWord(prfnm);
+            if (prfcast != null) performanceSearchService.updatePopularSearchWord(prfcast);
+        } catch (Exception e) {
+            log.warn("인기검색어 업데이트 실패 (검색 결과에는 영향 없음): {}", e.getMessage());
+        }
     }
 
     private BasePerformancesResponseDto createPerformanceDto(Elements element) {

--- a/src/test/java/com/example/calenduck/domain/performance/service/PerformanceServiceSearchTest.java
+++ b/src/test/java/com/example/calenduck/domain/performance/service/PerformanceServiceSearchTest.java
@@ -123,6 +123,18 @@ class PerformanceServiceSearchTest {
 
             verify(performanceSearchService).updatePopularSearchWord("캣츠");
         }
+
+        @Test
+        @DisplayName("인기검색어 업데이트 실패 시에도 검색 결과는 정상 반환한다")
+        void search_withRedisFailure_stillReturnsResults() throws Exception {
+            doThrow(new RuntimeException("Redis 연결 실패"))
+                    .when(performanceSearchService).updatePopularSearchWord(any());
+
+            List<BasePerformancesResponseDto> result = performanceService.getAllPerformances("캣츠", null);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getPrfnm()).contains("캣츠");
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- `updateSearchWord()`에서 Redis 예외 발생 시 검색 API 전체가 500 에러를 반환하던 문제 수정
- 인기검색어 업데이트는 부가 기능이므로 try-catch로 감싸 실패해도 검색 결과는 정상 반환
- Redis 실패 시나리오 단위 테스트 추가

## Test plan
- [ ] Redis 정상 시 검색 + 인기검색어 업데이트 정상 동작 확인
- [ ] Redis 비정상 시 검색 결과 정상 반환 확인
- [ ] 단위 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)