### PR TITLE
fix: Redis 캐시 역직렬화 ClassCastException 수정

### DIFF
--- a/src/main/java/com/example/calenduck/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/PerformanceService.java
@@ -2,6 +2,7 @@ package com.example.calenduck.domain.performance.service;
 
 import com.example.calenduck.domain.performance.dto.response.BasePerformancesResponseDto;
 import com.example.calenduck.domain.performance.http.BatchManager;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.select.Elements;
@@ -27,6 +28,7 @@ public class PerformanceService implements PerformanceServiceBehavior {
     private final PerformanceSearchBehavior performanceSearchService;
     private final BatchManager batchManager;
     private final CacheManager cacheManager;
+    private final ObjectMapper objectMapper;
 
     private static final String CACHE_NAME = "elementsCache";
     private static final String CACHE_KEY = "getAllPerformances";
@@ -72,13 +74,13 @@ public class PerformanceService implements PerformanceServiceBehavior {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private List<BasePerformancesResponseDto> getOrLoadAllPerformances() throws ExecutionException, InterruptedException {
         Cache cache = cacheManager.getCache(CACHE_NAME);
         if (cache != null) {
             Cache.ValueWrapper cached = cache.get(CACHE_KEY);
             if (cached != null) {
-                return (List<BasePerformancesResponseDto>) cached.get();
+                List<?> rawList = (List<?>) cached.get();
+                return safeCastCachedList(rawList);
             }
         }
 
@@ -131,6 +133,19 @@ public class PerformanceService implements PerformanceServiceBehavior {
         boolean nameMatch = lowerPrfnm != null && dto.getPrfnm().toLowerCase().contains(lowerPrfnm);
         boolean castMatch = lowerPrfcast != null && dto.getPrfcast().toLowerCase().contains(lowerPrfcast);
         return nameMatch || castMatch;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<BasePerformancesResponseDto> safeCastCachedList(List<?> rawList) {
+        if (rawList.isEmpty()) {
+            return Collections.emptyList();
+        }
+        if (rawList.get(0) instanceof BasePerformancesResponseDto) {
+            return (List<BasePerformancesResponseDto>) rawList;
+        }
+        return rawList.stream()
+                .map(item -> objectMapper.convertValue(item, BasePerformancesResponseDto.class))
+                .collect(Collectors.toList());
     }
 
     private List<BasePerformancesResponseDto> convertAllToDto(List<Elements> elements) {

--- a/src/test/java/com/example/calenduck/domain/performance/service/PerformanceServiceSearchTest.java
+++ b/src/test/java/com/example/calenduck/domain/performance/service/PerformanceServiceSearchTest.java
@@ -2,6 +2,7 @@ package com.example.calenduck.domain.performance.service;
 
 import com.example.calenduck.domain.performance.dto.response.BasePerformancesResponseDto;
 import com.example.calenduck.domain.performance.http.BatchManager;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jsoup.Jsoup;
 import org.jsoup.select.Elements;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +16,7 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,7 +59,7 @@ class PerformanceServiceSearchTest {
 
     @BeforeEach
     void setUp() {
-        performanceService = new PerformanceService(performanceSearchService, batchManager, cacheManager);
+        performanceService = new PerformanceService(performanceSearchService, batchManager, cacheManager, new ObjectMapper());
     }
 
     @Nested
@@ -150,6 +152,45 @@ class PerformanceServiceSearchTest {
             performanceService.getAllPerformances("캣츠", null);
 
             verify(batchManager, never()).getElements();
+        }
+
+        @Test
+        @DisplayName("캐시에서 LinkedHashMap으로 역직렬화된 데이터도 정상 변환하여 검색한다")
+        void search_withLinkedHashMapCache_convertsAndSearches() throws Exception {
+            when(cacheManager.getCache("elementsCache")).thenReturn(cache);
+
+            LinkedHashMap<String, String> map1 = new LinkedHashMap<>();
+            map1.put("mt20id", "PF001");
+            map1.put("poster", "poster1.jpg");
+            map1.put("prfnm", "뮤지컬 캣츠");
+            map1.put("prfcast", "배우A");
+            map1.put("genrenm", "뮤지컬");
+            map1.put("fcltynm", "극장1");
+            map1.put("dtguidance", "19:30");
+            map1.put("stdate", "2024.01.01");
+            map1.put("eddate", "2024.03.01");
+            map1.put("pcseguidance", "50000원");
+
+            LinkedHashMap<String, String> map2 = new LinkedHashMap<>();
+            map2.put("mt20id", "PF002");
+            map2.put("poster", "poster2.jpg");
+            map2.put("prfnm", "오페라의 유령");
+            map2.put("prfcast", "배우B");
+            map2.put("genrenm", "뮤지컬");
+            map2.put("fcltynm", "극장2");
+            map2.put("dtguidance", "19:30");
+            map2.put("stdate", "2024.01.01");
+            map2.put("eddate", "2024.03.01");
+            map2.put("pcseguidance", "60000원");
+
+            List<LinkedHashMap<String, String>> rawList = Arrays.asList(map1, map2);
+            when(cache.get("getAllPerformances")).thenReturn(() -> rawList);
+
+            List<BasePerformancesResponseDto> result = performanceService.getAllPerformances("캣츠", null);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getPrfnm()).contains("캣츠");
+            assertThat(result.get(0).getMt20id()).isEqualTo("PF001");
         }
 
         @Test

--- a/src/test/java/com/example/calenduck/domain/performance/service/PerformanceServiceTest.java
+++ b/src/test/java/com/example/calenduck/domain/performance/service/PerformanceServiceTest.java
@@ -7,6 +7,7 @@ import org.jsoup.select.Elements;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,6 +35,9 @@ class PerformanceServiceTest {
 
     @Mock
     private CacheManager cacheManager;
+
+    @Mock
+    private ObjectMapper objectMapper;
 
     @Mock
     private Cache cache;


### PR DESCRIPTION
## Summary
- Redis 캐시에서 `LinkedHashMap`으로 역직렬화되어 검색 시 `ClassCastException` 발생하던 버그 수정
- `safeCastCachedList()` 메서드로 캐시 데이터 타입을 확인 후 안전하게 DTO 변환
- `ObjectMapper.convertValue()`를 활용하여 `LinkedHashMap` → `BasePerformancesResponseDto` 변환

## Test plan
- [x] LinkedHashMap 캐시 데이터로 검색 시 정상 변환 테스트 추가
- [x] 기존 DTO 캐시 데이터 테스트 전체 통과 확인
- [ ] 서버 재시작 후 검색 기능 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)