### PR TITLE
feat: 인기검색어 클릭 시 검색 트리거

### DIFF
--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom'
 import { usePerformances } from '@/hooks/usePerformances'
 import { useSearchRank } from '@/hooks/useSearchRank'
 import PerformanceGrid from '@/components/performance/PerformanceGrid'
@@ -6,6 +7,7 @@ import { SkeletonGrid } from '@/components/common/SkeletonCard'
 import { TrendingUp, Sparkles } from 'lucide-react'
 
 export default function MainPage() {
+  const navigate = useNavigate()
   const { data: performances, isLoading, isError, refetch } = usePerformances()
   const { data: searchRanks } = useSearchRank()
 
@@ -36,13 +38,14 @@ export default function MainPage() {
           </div>
           <div className="flex flex-wrap gap-2">
             {searchRanks.map((item, index) => (
-              <span
+              <button
                 key={item.rankKeyword}
-                className="inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/5 px-3.5 py-1.5 text-sm transition-all hover:bg-primary/10 hover:shadow-sm cursor-default"
+                onClick={() => navigate(`/search?query=${encodeURIComponent(item.rankKeyword)}`)}
+                className="inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/5 px-3.5 py-1.5 text-sm transition-all hover:bg-primary/10 hover:shadow-sm cursor-pointer"
               >
                 <span className="font-bold text-primary">{index + 1}</span>
                 <span className="text-foreground">{item.rankKeyword}</span>
-              </span>
+              </button>
             ))}
           </div>
         </section>


### PR DESCRIPTION
## Summary
- 인기검색어 클릭 시 해당 키워드로 검색 페이지(`/search?query=키워드`)로 이동
- `<span>` → `<button>` 변경, `cursor-pointer` 적용

## Test plan
- [x] TypeScript 컴파일 확인
- [ ] 인기검색어 클릭 → 검색 페이지 이동 확인
- [ ] 검색 결과가 해당 키워드로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)