### PR TITLE
feat: 공연 목록 더 보기 페이지네이션

### DIFF
--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,13 +1,17 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { usePerformances } from '@/hooks/usePerformances'
 import { useSearchRank } from '@/hooks/useSearchRank'
 import PerformanceGrid from '@/components/performance/PerformanceGrid'
 import ErrorFallback from '@/components/common/ErrorFallback'
 import { SkeletonGrid } from '@/components/common/SkeletonCard'
-import { TrendingUp, Sparkles } from 'lucide-react'
+import { TrendingUp, Sparkles, ChevronDown } from 'lucide-react'
+
+const PAGE_SIZE = 20
 
 export default function MainPage() {
   const navigate = useNavigate()
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
   const { data: performances, isLoading, isError, refetch } = usePerformances()
   const { data: searchRanks } = useSearchRank()
 
@@ -58,7 +62,20 @@ export default function MainPage() {
         ) : isError ? (
           <ErrorFallback message="공연 목록을 불러올 수 없습니다." onRetry={() => refetch()} />
         ) : (
-          <PerformanceGrid performances={performances ?? []} />
+          <>
+            <PerformanceGrid performances={(performances ?? []).slice(0, visibleCount)} />
+            {performances && visibleCount < performances.length && (
+              <div className="mt-8 flex justify-center">
+                <button
+                  onClick={() => setVisibleCount((prev) => prev + PAGE_SIZE)}
+                  className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-6 py-2.5 text-sm font-medium text-foreground shadow-sm transition-all hover:bg-muted hover:shadow-md"
+                >
+                  <ChevronDown className="h-4 w-4" />
+                  더 보기 ({performances.length - visibleCount}개 남음)
+                </button>
+              </div>
+            )}
+          </>
         )}
       </section>
     </div>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,13 +1,17 @@
+import { useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { usePerformances } from '@/hooks/usePerformances'
 import PerformanceGrid from '@/components/performance/PerformanceGrid'
 import ErrorFallback from '@/components/common/ErrorFallback'
 import SearchBar from '@/components/common/SearchBar'
-import { Loader2, SearchX } from 'lucide-react'
+import { Loader2, SearchX, ChevronDown } from 'lucide-react'
+
+const PAGE_SIZE = 20
 
 export default function SearchPage() {
   const [searchParams] = useSearchParams()
   const query = searchParams.get('query') || ''
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
 
   const { data: performances, isLoading, isError, refetch } = usePerformances(query, query)
 
@@ -18,6 +22,9 @@ export default function SearchPage() {
         {query && (
           <p className="text-sm text-muted-foreground">
             <span className="font-medium text-foreground">"{query}"</span> 검색 결과
+            {performances && performances.length > 0 && (
+              <span className="ml-1">({performances.length}건)</span>
+            )}
           </p>
         )}
       </div>
@@ -29,7 +36,20 @@ export default function SearchPage() {
       ) : isError ? (
         <ErrorFallback message="검색 결과를 불러올 수 없습니다." onRetry={() => refetch()} />
       ) : performances && performances.length > 0 ? (
-        <PerformanceGrid performances={performances} />
+        <>
+          <PerformanceGrid performances={performances.slice(0, visibleCount)} />
+          {visibleCount < performances.length && (
+            <div className="mt-8 flex justify-center">
+              <button
+                onClick={() => setVisibleCount((prev) => prev + PAGE_SIZE)}
+                className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-6 py-2.5 text-sm font-medium text-foreground shadow-sm transition-all hover:bg-muted hover:shadow-md"
+              >
+                <ChevronDown className="h-4 w-4" />
+                더 보기 ({performances.length - visibleCount}개 남음)
+              </button>
+            </div>
+          )}
+        </>
       ) : (
         <div className="flex flex-col items-center justify-center gap-3 py-20">
           <SearchX className="h-12 w-12 text-muted-foreground/50" />


### PR DESCRIPTION
## Summary
- MainPage, SearchPage에 20개씩 "더 보기" 클라이언트 사이드 페이지네이션 추가
- 버튼에 남은 공연 수 표시
- SearchPage에 총 검색 결과 건수 표시

## Test plan
- [x] TypeScript 컴파일 확인
- [ ] 메인 페이지에서 20개만 표시 → "더 보기" 클릭 시 20개 추가 로드
- [ ] 검색 페이지에서도 동일 동작
- [ ] 전체 데이터보다 적을 때 "더 보기" 버튼 미표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)