### PR TITLE
feat: 랭킹 API Redash 의존 제거, 캐시 기반 재구현

### DIFF
--- a/src/main/java/com/example/calenduck/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/example/calenduck/domain/bookmark/repository/BookmarkRepository.java
@@ -2,12 +2,18 @@ package com.example.calenduck.domain.bookmark.repository;
 
 import com.example.calenduck.domain.bookmark.entity.Bookmark;
 import com.example.calenduck.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
 import java.util.List;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     List<Bookmark> findAllByUser(User user);
     Bookmark findByUserAndMt20idAndReservationDate(User user, String mt20id, String reservationDate);
+
+    @Query("SELECT b.mt20id, COUNT(b) FROM Bookmark b WHERE b.deletedAt IS NULL GROUP BY b.mt20id ORDER BY COUNT(b) DESC")
+    List<Object[]> findTopBookmarkedPerformances(Pageable pageable);
 
 }

--- a/src/main/java/com/example/calenduck/domain/performance/dto/response/RankingCountResponse.java
+++ b/src/main/java/com/example/calenduck/domain/performance/dto/response/RankingCountResponse.java
@@ -1,0 +1,11 @@
+package com.example.calenduck.domain.performance.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RankingCountResponse {
+    private final String name;
+    private final long count;
+}

--- a/src/main/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsBehavior.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsBehavior.java
@@ -1,9 +1,11 @@
 package com.example.calenduck.domain.performance.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.example.calenduck.domain.performance.dto.response.RankingCountResponse;
+
+import java.util.List;
 
 public interface PerformanceAnalyticsBehavior {
-    JsonNode popularityByGenreWithRegion(); // 지역별 장르 인기도
-    JsonNode topTen(); // 인기 공연 탑텐
-    JsonNode popularityByRegion(); // 지역별 인기 공연
+    List<RankingCountResponse> popularityByGenreWithRegion();
+    List<RankingCountResponse> topTen();
+    List<RankingCountResponse> popularityByRegion();
 }

--- a/src/main/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsService.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsService.java
@@ -1,169 +1,84 @@
 package com.example.calenduck.domain.performance.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.calenduck.domain.bookmark.repository.BookmarkRepository;
+import com.example.calenduck.domain.performance.dto.response.BasePerformancesResponseDto;
+import com.example.calenduck.domain.performance.dto.response.RankingCountResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class PerformanceAnalyticsService implements PerformanceAnalyticsBehavior {
 
-    @Value("${server.url}")
-    private String serverUrl;
+    private final PerformanceServiceBehavior performanceService;
+    private final BookmarkRepository bookmarkRepository;
 
-    @Value("${redash.api-key.genre-region}")
-    private String genreRegionApiKey;
+    private static final int TOP_TEN_SIZE = 10;
 
-    @Value("${redash.api-key.top-ten}")
-    private String topTenApiKey;
-
-    @Value("${redash.api-key.region}")
-    private String regionApiKey;
-
-    @Value("${http.connect-timeout}")
-    private int connectTimeout;
-
-    @Value("${http.read-timeout}")
-    private int readTimeout;
-
-    // 인기도 - 지역별 장르
     @Override
-    public JsonNode popularityByGenreWithRegion() {
-        String url = serverUrl + "/api/queries/3/results.json?api_key=" + genreRegionApiKey;
-        JsonNode rowsNode = null;
-
-        try {
-            URL apiUrl = new URL(url);
-            HttpURLConnection connection = (HttpURLConnection) apiUrl.openConnection();
-            connection.setRequestMethod("GET");
-            connection.setRequestProperty("Accept", "application/json");
-            connection.setConnectTimeout(connectTimeout);
-            connection.setReadTimeout(readTimeout);
-
-            int responseCode = connection.getResponseCode();
-            if (responseCode == HttpURLConnection.HTTP_OK) {
-                BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-                StringBuilder response = new StringBuilder();
-                String line;
-
-                while ((line = reader.readLine()) != null) {
-                    response.append(line);
-                }
-                reader.close();
-                String jsonResponse = response.toString();
-
-                ObjectMapper objectMapper = new ObjectMapper();
-                JsonNode jsonNode = objectMapper.readTree(jsonResponse);
-                JsonNode dataNode = jsonNode.path("query_result").path("data");
-                rowsNode = dataNode.path("rows");
-
-                for (JsonNode rowNode : rowsNode) {
-                    String area = rowNode.path("area_nm").asText();
-                    String genre = rowNode.path("genre_nm").asText();
-                    double value = rowNode.path("\uc608\ub9e4\uc728").asDouble();
-                    log.info("area: {}, genre: {}, value: {}", area, genre, value);
-                }
-                log.info("rowsNode: {}", Arrays.toString(new JsonNode[]{rowsNode}));
-            } else {
-                log.error("HTTP 실패 코드: {}", responseCode);
-            }
-            connection.disconnect();
-        } catch (IOException e) {
-            log.error("Redash API(지역별 장르) 호출 실패", e);
-        }
-        return rowsNode;
+    public List<RankingCountResponse> popularityByGenreWithRegion() {
+        List<BasePerformancesResponseDto> performances = getAllPerformancesSafely();
+        return performances.stream()
+                .collect(Collectors.groupingBy(BasePerformancesResponseDto::getGenrenm, Collectors.counting()))
+                .entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .map(entry -> new RankingCountResponse(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
     }
 
-    // 탑텐
     @Override
-    public JsonNode topTen() {
-        String url = serverUrl + "/api/queries/5/results.json?api_key=" + topTenApiKey;
-        JsonNode rowsNode = null;
-
-        try {
-            URL apiUrl = new URL(url);
-            HttpURLConnection connection = (HttpURLConnection) apiUrl.openConnection();
-            connection.setRequestMethod("GET");
-            connection.setRequestProperty("Accept", "application/json");
-            connection.setConnectTimeout(connectTimeout);
-            connection.setReadTimeout(readTimeout);
-
-            int responseCode = connection.getResponseCode();
-            if (responseCode == HttpURLConnection.HTTP_OK) {
-                BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-                StringBuilder response = new StringBuilder();
-                String line;
-
-                while ((line = reader.readLine()) != null) {
-                    response.append(line);
-                }
-                reader.close();
-                String jsonResponse = response.toString();
-
-                ObjectMapper objectMapper = new ObjectMapper();
-                JsonNode jsonNode = objectMapper.readTree(jsonResponse);
-                JsonNode dataNode = jsonNode.path("query_result").path("data");
-                rowsNode = dataNode.path("rows");
-
-                log.info("topTen rowsNode: {}", rowsNode);
-            } else {
-                log.error("HTTP 실패 코드: {}", responseCode);
-            }
-            connection.disconnect();
-        } catch (IOException e) {
-            log.error("Redash API(탑텐) 호출 실패", e);
+    public List<RankingCountResponse> topTen() {
+        List<Object[]> bookmarkCounts = bookmarkRepository.findTopBookmarkedPerformances(PageRequest.of(0, TOP_TEN_SIZE));
+        if (bookmarkCounts.isEmpty()) {
+            return Collections.emptyList();
         }
-        return rowsNode;
+
+        Map<String, String> performanceNames = getPerformanceNameMap();
+
+        return bookmarkCounts.stream()
+                .map(row -> {
+                    String mt20id = (String) row[0];
+                    long count = (Long) row[1];
+                    String name = performanceNames.getOrDefault(mt20id, mt20id);
+                    return new RankingCountResponse(name, count);
+                })
+                .collect(Collectors.toList());
     }
 
-    // 지역별 인기 공연
     @Override
-    public JsonNode popularityByRegion() {
-        String url = serverUrl + "/api/queries/1/results.json?api_key=" + regionApiKey;
-        JsonNode rowsNode = null;
+    public List<RankingCountResponse> popularityByRegion() {
+        List<BasePerformancesResponseDto> performances = getAllPerformancesSafely();
+        return performances.stream()
+                .collect(Collectors.groupingBy(BasePerformancesResponseDto::getFcltynm, Collectors.counting()))
+                .entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .map(entry -> new RankingCountResponse(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
 
+    private List<BasePerformancesResponseDto> getAllPerformancesSafely() {
         try {
-            URL apiUrl = new URL(url);
-            HttpURLConnection connection = (HttpURLConnection) apiUrl.openConnection();
-            connection.setRequestMethod("GET");
-            connection.setRequestProperty("Accept", "application/json");
-            connection.setConnectTimeout(connectTimeout);
-            connection.setReadTimeout(readTimeout);
-
-            int responseCode = connection.getResponseCode();
-            if (responseCode == HttpURLConnection.HTTP_OK) {
-                BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-                StringBuilder response = new StringBuilder();
-                String line;
-
-                while ((line = reader.readLine()) != null) {
-                    response.append(line);
-                }
-                reader.close();
-                String jsonResponse = response.toString();
-
-                ObjectMapper objectMapper = new ObjectMapper();
-                JsonNode jsonNode = objectMapper.readTree(jsonResponse);
-                JsonNode dataNode = jsonNode.path("query_result").path("data");
-                rowsNode = dataNode.path("rows");
-
-                log.info("rowsNode: {}", Arrays.toString(new JsonNode[]{rowsNode}));
-            } else {
-                log.error("HTTP 실패 코드: {}", responseCode);
-            }
-            connection.disconnect();
-        } catch (IOException e) {
-            log.error("Redash API(지역별 인기) 호출 실패", e);
+            return performanceService.getAllPerformances(null, null);
+        } catch (Exception e) {
+            log.error("공연 데이터 로드 실패", e);
+            return Collections.emptyList();
         }
-        return rowsNode;
+    }
+
+    private Map<String, String> getPerformanceNameMap() {
+        return getAllPerformancesSafely().stream()
+                .collect(Collectors.toMap(
+                        BasePerformancesResponseDto::getMt20id,
+                        BasePerformancesResponseDto::getPrfnm,
+                        (existing, replacement) -> existing
+                ));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,12 +54,12 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect_url: ${KAKAO_REDIRECT_URL}
 
-# ===== Redash API =====
-redash:
-  api-key:
-    genre-region: ${REDASH_API_KEY_GENRE_REGION}
-    top-ten: ${REDASH_API_KEY_TOP_TEN}
-    region: ${REDASH_API_KEY_REGION}
+# ===== Redash API (미사용 — 캐시 기반으로 대체) =====
+# redash:
+#   api-key:
+#     genre-region: ${REDASH_API_KEY_GENRE_REGION}
+#     top-ten: ${REDASH_API_KEY_TOP_TEN}
+#     region: ${REDASH_API_KEY_REGION}
 
 # ===== KOPIS API =====
 kopis:

--- a/src/test/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsServiceTest.java
+++ b/src/test/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsServiceTest.java
@@ -1,0 +1,129 @@
+package com.example.calenduck.domain.performance.service;
+
+import com.example.calenduck.domain.bookmark.repository.BookmarkRepository;
+import com.example.calenduck.domain.performance.dto.response.BasePerformancesResponseDto;
+import com.example.calenduck.domain.performance.dto.response.RankingCountResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PerformanceAnalyticsServiceTest {
+
+    @Mock
+    private PerformanceServiceBehavior performanceService;
+
+    @Mock
+    private BookmarkRepository bookmarkRepository;
+
+    private PerformanceAnalyticsService analyticsService;
+
+    private List<BasePerformancesResponseDto> samplePerformances() {
+        return Arrays.asList(
+                new BasePerformancesResponseDto("PF001", "p1.jpg", "뮤지컬 캣츠", "배우A", "뮤지컬", "세종문화회관", "19:30", "2024.01.01", "2024.03.01", "50000원"),
+                new BasePerformancesResponseDto("PF002", "p2.jpg", "오페라의 유령", "배우B", "뮤지컬", "예술의전당", "19:30", "2024.01.01", "2024.03.01", "60000원"),
+                new BasePerformancesResponseDto("PF003", "p3.jpg", "햄릿", "배우C", "연극", "세종문화회관", "20:00", "2024.02.01", "2024.04.01", "40000원"),
+                new BasePerformancesResponseDto("PF004", "p4.jpg", "백조의 호수", "배우D", "무용", "예술의전당", "19:00", "2024.01.15", "2024.03.15", "70000원"),
+                new BasePerformancesResponseDto("PF005", "p5.jpg", "라보엠", "배우E", "뮤지컬", "LG아트센터", "19:30", "2024.02.01", "2024.05.01", "55000원")
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+        analyticsService = new PerformanceAnalyticsService(performanceService, bookmarkRepository);
+    }
+
+    @Nested
+    @DisplayName("장르별 공연 수 집계")
+    class GenreRanking {
+
+        @Test
+        @DisplayName("캐시된 공연을 장르별로 집계하여 내림차순 반환한다")
+        void genreRanking_groupsByGenreDescending() throws Exception {
+            when(performanceService.getAllPerformances(null, null)).thenReturn(samplePerformances());
+
+            List<RankingCountResponse> result = analyticsService.popularityByGenreWithRegion();
+
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).getName()).isEqualTo("뮤지컬");
+            assertThat(result.get(0).getCount()).isEqualTo(3);
+            assertThat(result.get(1).getName()).isEqualTo("연극");
+            assertThat(result.get(1).getCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("캐시가 비어있으면 빈 리스트를 반환한다")
+        void genreRanking_emptyCache_returnsEmpty() throws Exception {
+            when(performanceService.getAllPerformances(null, null)).thenReturn(Collections.emptyList());
+
+            List<RankingCountResponse> result = analyticsService.popularityByGenreWithRegion();
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("시설별 공연 수 집계")
+    class FacilityRanking {
+
+        @Test
+        @DisplayName("캐시된 공연을 시설별로 집계하여 내림차순 반환한다")
+        void facilityRanking_groupsByFacilityDescending() throws Exception {
+            when(performanceService.getAllPerformances(null, null)).thenReturn(samplePerformances());
+
+            List<RankingCountResponse> result = analyticsService.popularityByRegion();
+
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).getCount()).isEqualTo(2);
+            assertThat(result.get(1).getCount()).isEqualTo(2);
+            assertThat(result.get(2).getCount()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("Top 10 인기 공연 (북마크 기준)")
+    class TopTenRanking {
+
+        @Test
+        @DisplayName("북마크 수 기준 Top 10 공연을 반환한다")
+        void topTen_returnsByBookmarkCount() throws Exception {
+            List<Object[]> bookmarkCounts = Arrays.asList(
+                    new Object[]{"PF001", 15L},
+                    new Object[]{"PF003", 8L}
+            );
+            when(bookmarkRepository.findTopBookmarkedPerformances(any(Pageable.class))).thenReturn(bookmarkCounts);
+            when(performanceService.getAllPerformances(null, null)).thenReturn(samplePerformances());
+
+            List<RankingCountResponse> result = analyticsService.topTen();
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getName()).isEqualTo("뮤지컬 캣츠");
+            assertThat(result.get(0).getCount()).isEqualTo(15);
+            assertThat(result.get(1).getName()).isEqualTo("햄릿");
+            assertThat(result.get(1).getCount()).isEqualTo(8);
+        }
+
+        @Test
+        @DisplayName("북마크가 없으면 빈 리스트를 반환한다")
+        void topTen_noBookmarks_returnsEmpty() throws Exception {
+            when(bookmarkRepository.findTopBookmarkedPerformances(any(Pageable.class))).thenReturn(Collections.emptyList());
+
+            List<RankingCountResponse> result = analyticsService.topTen();
+
+            assertThat(result).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Redash API 의존을 제거하고 캐시 데이터 + 북마크 기반으로 랭킹 API 재구현
- 장르별: 캐시된 공연의 `genrenm`으로 GROUP BY 집계
- Top 10: `BookmarkRepository` 쿼리로 북마크 수 기준 인기 공연
- 시설별: 캐시된 공연의 `fcltynm`으로 GROUP BY 집계
- `RankingCountResponse` DTO 추가 (name, count)
- application.yml에서 Redash 설정 비활성화

## Test plan
- [x] PerformanceAnalyticsServiceTest — 장르별/시설별/Top10 테스트 통과
- [x] 기존 전체 테스트 통과
- [ ] 서버 재시작 후 `/performances/topten`, `/performances/popularity/region`, `/performances/popularity/genres/region` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)