### PR TITLE
feat: 랭킹 프론트엔드를 공연 카드 기반으로 재설계

### DIFF
--- a/frontend/src/api/performance.ts
+++ b/frontend/src/api/performance.ts
@@ -1,6 +1,6 @@
 import client from './client'
 import type { ApiResponse } from '@/types/api'
-import type { Performance, SearchRank } from '@/types/performance'
+import type { Performance, SearchRank, RankingCount } from '@/types/performance'
 
 export async function getPerformances(prfnm?: string, prfcast?: string) {
   const params = new URLSearchParams()
@@ -23,16 +23,16 @@ export async function getSearchRank() {
 }
 
 export async function getTopTen() {
-  const { data } = await client.get<ApiResponse<unknown>>('/performances/topten')
+  const { data } = await client.get<ApiResponse<RankingCount[]>>('/performances/topten')
   return data.data
 }
 
 export async function getPopularityByRegion() {
-  const { data } = await client.get<ApiResponse<unknown>>('/performances/popularity/region')
+  const { data } = await client.get<ApiResponse<RankingCount[]>>('/performances/popularity/region')
   return data.data
 }
 
 export async function getPopularityByGenreRegion() {
-  const { data } = await client.get<ApiResponse<unknown>>('/performances/popularity/genres/region')
+  const { data } = await client.get<ApiResponse<RankingCount[]>>('/performances/popularity/genres/region')
   return data.data
 }

--- a/frontend/src/hooks/useRanking.ts
+++ b/frontend/src/hooks/useRanking.ts
@@ -1,11 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 import { getTopTen, getPopularityByRegion, getPopularityByGenreRegion } from '@/api/performance'
 import { mockTopTen, mockPopularityByRegion, mockPopularityByGenreRegion } from '@/mocks/rankings'
+import type { RankingCount } from '@/types/performance'
 
 const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true'
 
 export function useTopTen() {
-  return useQuery({
+  return useQuery<RankingCount[]>({
     queryKey: ['topTen'],
     queryFn: async () => {
       if (USE_MOCK) return mockTopTen
@@ -16,7 +17,7 @@ export function useTopTen() {
 }
 
 export function usePopularityByRegion() {
-  return useQuery({
+  return useQuery<RankingCount[]>({
     queryKey: ['popularityByRegion'],
     queryFn: async () => {
       if (USE_MOCK) return mockPopularityByRegion
@@ -27,7 +28,7 @@ export function usePopularityByRegion() {
 }
 
 export function usePopularityByGenreRegion() {
-  return useQuery({
+  return useQuery<RankingCount[]>({
     queryKey: ['popularityByGenreRegion'],
     queryFn: async () => {
       if (USE_MOCK) return mockPopularityByGenreRegion

--- a/frontend/src/mocks/rankings.ts
+++ b/frontend/src/mocks/rankings.ts
@@ -1,28 +1,30 @@
-export const mockTopTen = [
-  { rank: 1, name: '오페라의 유령', count: 1520 },
-  { rank: 2, name: '위키드', count: 1340 },
-  { rank: 3, name: '햄릿', count: 1120 },
-  { rank: 4, name: '백조의 호수', count: 980 },
-  { rank: 5, name: '서울시향 정기 연주회', count: 870 },
-  { rank: 6, name: '시카고', count: 760 },
-  { rank: 7, name: '캣츠', count: 650 },
-  { rank: 8, name: '레미제라블', count: 540 },
-  { rank: 9, name: '맘마미아', count: 430 },
-  { rank: 10, name: '킹키부츠', count: 320 },
+import type { RankingCount } from '@/types/performance'
+
+export const mockTopTen: RankingCount[] = [
+  { name: '오페라의 유령', count: 1520 },
+  { name: '위키드', count: 1340 },
+  { name: '햄릿', count: 1120 },
+  { name: '백조의 호수', count: 980 },
+  { name: '서울시향 정기 연주회', count: 870 },
+  { name: '시카고', count: 760 },
+  { name: '캣츠', count: 650 },
+  { name: '레미제라블', count: 540 },
+  { name: '맘마미아', count: 430 },
+  { name: '킹키부츠', count: 320 },
 ]
 
-export const mockPopularityByRegion = [
-  { region: '서울', count: 5200 },
-  { region: '경기', count: 2100 },
-  { region: '부산', count: 1800 },
-  { region: '대구', count: 1200 },
-  { region: '인천', count: 900 },
+export const mockPopularityByRegion: RankingCount[] = [
+  { name: '세종문화회관', count: 52 },
+  { name: '예술의전당', count: 38 },
+  { name: 'LG아트센터', count: 25 },
+  { name: '국립극장', count: 18 },
+  { name: '대학로극장', count: 12 },
 ]
 
-export const mockPopularityByGenreRegion = [
-  { genre: '뮤지컬', region: '서울', count: 3200 },
-  { genre: '뮤지컬', region: '경기', count: 1100 },
-  { genre: '연극', region: '서울', count: 1800 },
-  { genre: '콘서트', region: '서울', count: 1500 },
-  { genre: '클래식', region: '서울', count: 800 },
+export const mockPopularityByGenreRegion: RankingCount[] = [
+  { name: '뮤지컬', count: 45 },
+  { name: '연극', count: 32 },
+  { name: '콘서트', count: 28 },
+  { name: '클래식', count: 15 },
+  { name: '무용', count: 8 },
 ]

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -1,18 +1,22 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useTopTen, usePopularityByRegion, usePopularityByGenreRegion } from '@/hooks/useRanking'
+import { usePerformances } from '@/hooks/usePerformances'
+import PerformanceGrid from '@/components/performance/PerformanceGrid'
 import ErrorFallback from '@/components/common/ErrorFallback'
-import { TrendingUp, Loader2, Trophy, MapPin, Music } from 'lucide-react'
+import { TrendingUp, Loader2, Trophy, MapPin, Music, Inbox } from 'lucide-react'
+import type { RankingCount, Performance } from '@/types/performance'
 
-type Tab = 'topten' | 'region' | 'genre'
+type Tab = 'topten' | 'facility' | 'genre'
 
 const tabs: { key: Tab; label: string; icon: typeof Trophy }[] = [
   { key: 'topten', label: 'TOP 10', icon: Trophy },
-  { key: 'region', label: '지역별', icon: MapPin },
+  { key: 'facility', label: '시설별', icon: MapPin },
   { key: 'genre', label: '장르별', icon: Music },
 ]
 
 export default function RankingPage() {
   const [activeTab, setActiveTab] = useState<Tab>('topten')
+  const { data: performances } = usePerformances()
 
   return (
     <div className="space-y-6">
@@ -38,130 +42,131 @@ export default function RankingPage() {
         ))}
       </div>
 
-      {activeTab === 'topten' && <TopTenSection />}
-      {activeTab === 'region' && <RegionSection />}
-      {activeTab === 'genre' && <GenreSection />}
+      {activeTab === 'topten' && <TopTenSection performances={performances ?? []} />}
+      {activeTab === 'facility' && <FacilitySection performances={performances ?? []} />}
+      {activeTab === 'genre' && <GenreSection performances={performances ?? []} />}
     </div>
   )
 }
 
-function TopTenSection() {
-  const { data, isLoading, isError, refetch } = useTopTen()
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-20">
+      <Inbox className="h-12 w-12 text-muted-foreground/50" />
+      <p className="text-muted-foreground">{message}</p>
+    </div>
+  )
+}
+
+function CategoryChips({
+  items,
+  selected,
+  onSelect,
+}: {
+  items: RankingCount[]
+  selected: string | null
+  onSelect: (name: string) => void
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {items.map((item) => (
+        <button
+          key={item.name}
+          onClick={() => onSelect(item.name)}
+          className={`inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-sm transition-all ${
+            selected === item.name
+              ? 'border-primary bg-primary text-primary-foreground shadow-md'
+              : 'border-border/60 bg-card text-foreground hover:bg-muted hover:shadow-sm'
+          }`}
+        >
+          <span className="font-medium">{item.name}</span>
+          <span className={`text-xs ${selected === item.name ? 'text-primary-foreground/70' : 'text-muted-foreground'}`}>
+            {item.count}
+          </span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function TopTenSection({ performances }: { performances: Performance[] }) {
+  const { data: ranking, isLoading, isError, refetch } = useTopTen()
+
+  const topPerformances = useMemo(() => {
+    if (!ranking || !performances.length) return []
+    const perfMap = new Map(performances.map((p) => [p.mt20id, p]))
+    return ranking
+      .map((r) => perfMap.get(r.id ?? ''))
+      .filter((p): p is Performance => p !== undefined)
+  }, [ranking, performances])
 
   if (isLoading) return <LoadingState />
   if (isError) return <ErrorFallback message="TOP 10 데이터를 불러올 수 없습니다." onRetry={() => refetch()} />
-  if (!data || !Array.isArray(data)) return null
+  if (!ranking || ranking.length === 0) return <EmptyState message="아직 북마크된 공연이 없습니다." />
+  if (topPerformances.length === 0) return <EmptyState message="공연 데이터를 불러오는 중입니다." />
 
   return (
-    <div className="space-y-2.5">
-      {data.map((item: Record<string, unknown>, index: number) => {
-        const name = (item.name || item.prfnm || '') as string
-        const count = (item.count || item.cnt || 0) as number
-        const rank = index + 1
-        const maxCount = (data[0] as Record<string, unknown>)?.count as number || (data[0] as Record<string, unknown>)?.cnt as number || 1
-
-        return (
-          <div
-            key={index}
-            className="flex items-center gap-4 rounded-2xl border border-border/60 bg-card p-4 shadow-sm transition-all hover:shadow-md"
-          >
-            <span
-              className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-bold shadow-sm ${
-                rank <= 3
-                  ? 'bg-gradient-to-br from-primary to-coral text-white'
-                  : 'bg-muted text-muted-foreground'
-              }`}
-            >
-              {rank}
-            </span>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-semibold text-card-foreground truncate">{name}</p>
-              <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted">
-                <div
-                  className="h-full rounded-full bg-gradient-to-r from-primary to-primary/60 transition-all duration-500"
-                  style={{ width: `${(count / maxCount) * 100}%` }}
-                />
-              </div>
-            </div>
-            <span className="shrink-0 text-xs font-medium text-muted-foreground">{count.toLocaleString()}</span>
-          </div>
-        )
-      })}
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">북마크가 많은 인기 공연</p>
+      <PerformanceGrid performances={topPerformances} />
     </div>
   )
 }
 
-function RegionSection() {
-  const { data, isLoading, isError, refetch } = usePopularityByRegion()
+function FacilitySection({ performances }: { performances: Performance[] }) {
+  const { data: facilities, isLoading, isError, refetch } = usePopularityByRegion()
+  const [selected, setSelected] = useState<string | null>(null)
+
+  const filtered = useMemo(() => {
+    if (!selected) return []
+    return performances.filter((p) => p.fcltynm === selected)
+  }, [performances, selected])
 
   if (isLoading) return <LoadingState />
-  if (isError) return <ErrorFallback message="지역별 인기 데이터를 불러올 수 없습니다." onRetry={() => refetch()} />
-  if (!data || !Array.isArray(data)) return null
-
-  const maxCount = Math.max(...data.map((item: Record<string, unknown>) => (item.count || item.cnt || 0) as number))
+  if (isError) return <ErrorFallback message="시설별 데이터를 불러올 수 없습니다." onRetry={() => refetch()} />
+  if (!facilities || facilities.length === 0) return <EmptyState message="시설별 데이터가 없습니다." />
 
   return (
-    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-      {data.map((item: Record<string, unknown>, index: number) => {
-        const region = (item.region || item.area || '') as string
-        const count = (item.count || item.cnt || 0) as number
-
-        return (
-          <div key={index} className="rounded-2xl border border-border/60 bg-card p-4 shadow-sm transition-all hover:shadow-md">
-            <div className="flex items-center justify-between mb-3">
-              <span className="text-sm font-bold text-card-foreground">{region}</span>
-              <span className="rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-semibold text-primary">{count.toLocaleString()}</span>
-            </div>
-            <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-              <div
-                className="h-full rounded-full bg-gradient-to-r from-primary to-coral/60 transition-all duration-500"
-                style={{ width: `${(count / maxCount) * 100}%` }}
-              />
-            </div>
-          </div>
+    <div className="space-y-6">
+      <CategoryChips items={facilities} selected={selected} onSelect={setSelected} />
+      {selected ? (
+        filtered.length > 0 ? (
+          <PerformanceGrid performances={filtered} />
+        ) : (
+          <EmptyState message="해당 시설의 공연이 없습니다." />
         )
-      })}
+      ) : (
+        <p className="py-10 text-center text-sm text-muted-foreground">시설을 선택하면 해당 공연을 볼 수 있습니다.</p>
+      )}
     </div>
   )
 }
 
-function GenreSection() {
-  const { data, isLoading, isError, refetch } = usePopularityByGenreRegion()
+function GenreSection({ performances }: { performances: Performance[] }) {
+  const { data: genres, isLoading, isError, refetch } = usePopularityByGenreRegion()
+  const [selected, setSelected] = useState<string | null>(null)
+
+  const filtered = useMemo(() => {
+    if (!selected) return []
+    return performances.filter((p) => p.genrenm === selected)
+  }, [performances, selected])
 
   if (isLoading) return <LoadingState />
-  if (isError) return <ErrorFallback message="장르별 인기 데이터를 불러올 수 없습니다." onRetry={() => refetch()} />
-  if (!data || !Array.isArray(data)) return null
+  if (isError) return <ErrorFallback message="장르별 데이터를 불러올 수 없습니다." onRetry={() => refetch()} />
+  if (!genres || genres.length === 0) return <EmptyState message="장르별 데이터가 없습니다." />
 
   return (
-    <div className="overflow-hidden rounded-2xl border border-border/60 bg-card shadow-sm">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-border/60 bg-muted/30">
-            <th className="px-5 py-3.5 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">장르</th>
-            <th className="px-5 py-3.5 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">지역</th>
-            <th className="px-5 py-3.5 text-right text-xs font-semibold uppercase tracking-wider text-muted-foreground">인기도</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((item: Record<string, unknown>, index: number) => {
-            const genre = (item.genre || item.genrenm || '') as string
-            const region = (item.region || item.area || '') as string
-            const count = (item.count || item.cnt || 0) as number
-
-            return (
-              <tr key={index} className="border-b border-border/40 last:border-0 transition-colors hover:bg-primary/5">
-                <td className="px-5 py-3.5 font-semibold text-card-foreground">{genre}</td>
-                <td className="px-5 py-3.5 text-muted-foreground">{region}</td>
-                <td className="px-5 py-3.5 text-right">
-                  <span className="rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-semibold text-primary">
-                    {count.toLocaleString()}
-                  </span>
-                </td>
-              </tr>
-            )
-          })}
-        </tbody>
-      </table>
+    <div className="space-y-6">
+      <CategoryChips items={genres} selected={selected} onSelect={setSelected} />
+      {selected ? (
+        filtered.length > 0 ? (
+          <PerformanceGrid performances={filtered} />
+        ) : (
+          <EmptyState message="해당 장르의 공연이 없습니다." />
+        )
+      ) : (
+        <p className="py-10 text-center text-sm text-muted-foreground">장르를 선택하면 해당 공연을 볼 수 있습니다.</p>
+      )}
     </div>
   )
 }

--- a/frontend/src/types/performance.ts
+++ b/frontend/src/types/performance.ts
@@ -15,3 +15,9 @@ export interface SearchRank {
   rankKeyword: string
   rank: number
 }
+
+export interface RankingCount {
+  id?: string
+  name: string
+  count: number
+}

--- a/src/main/java/com/example/calenduck/domain/performance/dto/response/RankingCountResponse.java
+++ b/src/main/java/com/example/calenduck/domain/performance/dto/response/RankingCountResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class RankingCountResponse {
+    private final String id;
     private final String name;
     private final long count;
 }

--- a/src/main/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsService.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsService.java
@@ -30,7 +30,7 @@ public class PerformanceAnalyticsService implements PerformanceAnalyticsBehavior
                 .collect(Collectors.groupingBy(BasePerformancesResponseDto::getGenrenm, Collectors.counting()))
                 .entrySet().stream()
                 .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
-                .map(entry -> new RankingCountResponse(entry.getKey(), entry.getValue()))
+                .map(entry -> new RankingCountResponse(null, entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
     }
 
@@ -48,7 +48,7 @@ public class PerformanceAnalyticsService implements PerformanceAnalyticsBehavior
                     String mt20id = (String) row[0];
                     long count = (Long) row[1];
                     String name = performanceNames.getOrDefault(mt20id, mt20id);
-                    return new RankingCountResponse(name, count);
+                    return new RankingCountResponse(mt20id, name, count);
                 })
                 .collect(Collectors.toList());
     }
@@ -60,7 +60,7 @@ public class PerformanceAnalyticsService implements PerformanceAnalyticsBehavior
                 .collect(Collectors.groupingBy(BasePerformancesResponseDto::getFcltynm, Collectors.counting()))
                 .entrySet().stream()
                 .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
-                .map(entry -> new RankingCountResponse(entry.getKey(), entry.getValue()))
+                .map(entry -> new RankingCountResponse(null, entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsServiceTest.java
+++ b/src/test/java/com/example/calenduck/domain/performance/service/PerformanceAnalyticsServiceTest.java
@@ -110,8 +110,10 @@ class PerformanceAnalyticsServiceTest {
             List<RankingCountResponse> result = analyticsService.topTen();
 
             assertThat(result).hasSize(2);
+            assertThat(result.get(0).getId()).isEqualTo("PF001");
             assertThat(result.get(0).getName()).isEqualTo("뮤지컬 캣츠");
             assertThat(result.get(0).getCount()).isEqualTo(15);
+            assertThat(result.get(1).getId()).isEqualTo("PF003");
             assertThat(result.get(1).getName()).isEqualTo("햄릿");
             assertThat(result.get(1).getCount()).isEqualTo(8);
         }


### PR DESCRIPTION
## Summary
- Top 10: 북마크 기준 인기 공연을 PerformanceGrid(공연 카드)로 표시
- 시설별: 카테고리 칩 선택 → 해당 시설 공연 카드 그리드 표시
- 장르별: 카테고리 칩 선택 → 해당 장르 공연 카드 그리드 표시
- RankingCountResponse에 id 필드 추가 (Top 10 공연 매칭용)
- API/Hook 타입을 RankingCount[]로 명확화

## Test plan
- [x] `./gradlew test` 백엔드 테스트 통과
- [x] `npx tsc --noEmit` TypeScript 컴파일 통과
- [ ] 브라우저에서 랭킹 페이지 Top 10 탭 → 공연 카드 표시 확인
- [ ] 시설별 탭 → 칩 클릭 → 해당 시설 공연 표시 확인
- [ ] 장르별 탭 → 칩 클릭 → 해당 장르 공연 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)